### PR TITLE
Problems with byte to character offset convertion

### DIFF
--- a/src/java/org/eclim/plugin/jdt/command/search/SearchCommand.java
+++ b/src/java/org/eclim/plugin/jdt/command/search/SearchCommand.java
@@ -154,8 +154,7 @@ public class SearchCommand
       String encoding = commandLine.getValue(Options.ENCODING_OPTION);
       String filepath = ProjectUtils.getFilePath(project, file);
 
-      int charOffset = FileUtils.byteOffsetToCharOffset(
-          filepath, getOffset(commandLine), encoding);
+	  int charOffset = getOffset(commandLine);
       Position position = new Position(
           file, charOffset, Integer.parseInt(length));
       IJavaElement element = getElement(project, position);


### PR DESCRIPTION
Hi there!

I'm one of the developers of emacs-eclim, and I've been noticing strange errors when calling 'java_search' when my source code contains multi-byte UTF-8 characters (such as the common swedish chars å, ä and ö). At first I was thought that my byte offset counting routines were off, but after doing some experiments I'm reasonably sure that they are correct.

I then noticed that the command 'java_complete' did work as expected when given the same offset, so I had a look at SearchCommand.java and CodeCompleteCommand.java and noticed a difference in how the offset supplied with the -o arguments was handled. In SearchCommand.java the value was converted to a character offset using FileUtils.byteOffsetToCharOffset(), but that doesn't happen in CodeCompleteCommand.java. However, both classes call methods on the interface ICompilationUnit, whose javadoc states that it expects a character offset. 

This is where it gets confusing (for me at least), since it seems that what ICompilationUnit _really_ wants is the byte offset. If I remove the byte offset->char offset conversion in SearchCommand.jar it too works as I expect it to.

Since I'm not a Vim user I may be way off base here. It could be that what really should be happening is that both commands should to a proper offset conversion before calling ICompilationUnit and that by own byte offset calculation is wrong, or maybe I'm missing something else. However, I'd be glad if you could have a look at this and tell me if I'm on the right track or not.

Cheers, and thanks for creating eclim. It's made a world of difference for me as an emacs user ;)
-- Fredrik
