### PR TITLE
the package of SearchUtils has changed from dltk to jdt

### DIFF
--- a/src/java/org/eclim/plugin/dltk/command/search/SearchCommand.java
+++ b/src/java/org/eclim/plugin/dltk/command/search/SearchCommand.java
@@ -59,7 +59,7 @@ import org.eclipse.dltk.core.search.SearchMatch;
 import org.eclipse.dltk.core.search.SearchParticipant;
 import org.eclipse.dltk.core.search.SearchPattern;
 
-import org.eclipse.dltk.internal.corext.util.SearchUtils;
+import org.eclipse.jdt.internal.corext.util.SearchUtils;
 
 import org.eclipse.dltk.internal.ui.search.DLTKSearchScopeFactory;
 


### PR DESCRIPTION
the package of SearchUtils has changed from dltk to jdt (at least in my Eclipse (Indigo))
