### PR TITLE
Patch for problem when opening a second file in Vim from Eclipse when Vim is in insert mode.

### DIFF
--- a/org.eclim.vimplugin/java/org/vimplugin/VimServer.java
+++ b/org.eclim.vimplugin/java/org/vimplugin/VimServer.java
@@ -154,7 +154,7 @@ public class VimServer
       args[1] = "--servername";
       args[2] = String.valueOf(ID);
       args[3] = "--remote-send";
-      args[4] = ":tabnew<cr>:Tcd " + workingDir.replace(" ", "\\ ") + "<cr>";
+      args[4] = "<esc>:tabnew<cr>:Tcd " + workingDir.replace(" ", "\\ ") + "<cr>";
       System.arraycopy(addopts, 0, args, 5, addopts.length);
 
       start(workingDir, false, (tabbed && !first), args);


### PR DESCRIPTION
Problem: If Vim is in insert mode when Eclipse/Eclim sends a second file to Vim in a new tab, the normal mode commands ":tabnew<cr>:Tcd ...dirname" are typed into the current buffer and then the new file is opened in the same tab.

To Reproduce:
1. Running in a Headed Eclipse server, configure Eclim/Vimplugin to (1) DO NOT embed vim and (2) DO open files in new Vim tabs.
2. In Eclipse, open a file in Vim.
3. Put Vim in insert mode.
4. In Eclipse, open another file in Vim.

Proposed solution: Send <esc> before the normal-mode commands ":tabnew...".

As a side note, there are other uses of --remote-send and of VimConnection.remotesend() in the source and I was not able to cause trouble through anything like the steps above.

One point I'm not sure of is a call to vc.remotesend(":saveas! " ...) if the VimEditor isDirty() in VimEditor.doSetInput().  I'm not familiar enough with the TextEditor class to understand the context in which that method is called and the Eclipse Platform API didn't enlighten me fully with a brief read at any rate.
