### PR TITLE
 Fix dltk and dltk-ruby feature recognition

### DIFF
--- a/ant/build.gant
+++ b/ant/build.gant
@@ -688,6 +688,7 @@ def initPlugins(){
   if (dropins.exists()){
     dropins.eachDir{ dropin ->
       featurePaths << new File(dropin.getAbsolutePath() + '/eclipse/features')
+      featurePaths << new File(dropin.getAbsolutePath() + '/features')
     }
   }
   if (getVariable('eclipse') != getVariable('eclipse.local')){


### PR DESCRIPTION
It seems the features folder is now at dltk-core/features rather than
dltk-core/eclipse/features on the most recent version. The same 
goes for dltk-ruby.

This one-liner fixes the feature recognition when using the latest
released version of the above plugins.
