### PR TITLE
Fix for using Buffer Explorer plugin with Eclim

### DIFF
--- a/org.eclim.core/vim/eclim/autoload/eclim/display/window.vim
+++ b/org.eclim.core/vim/eclim/autoload/eclim/display/window.vim
@@ -223,7 +223,9 @@ function! s:CloseIfLastWindow() " {{{
       endif
       let buftype = getbufvar(bufnr, '&buftype')
       if buftype != '' && buftype != 'help'
-        continue
+        if !exists('g:BufExplorer_title') || bufname(bufnr) != "[BufExplorer]"
+          continue
+	     	endif
       endif
 
       let close = 0


### PR DESCRIPTION
Since 'buftype' of "Buffer Explorer" plugin window is equal to "nofile",
CloseIfLastWindow function closes vim instance (using 'quitall')
when I switch from "Buffer Explorer" window to ProjectsTree window.

This fix adds exception for special buftype with title "[BufExplorer]".

Buffer Explorer: http://www.vim.org/scripts/script.php?script_id=42
