### PR TITLE
Patch for Issue #156 to fix inappropriate Semantic Errors when validating nested struct definitions.

### DIFF
--- a/org.eclim.cdt/java/org/eclim/plugin/cdt/command/src/SrcUpdateCommand.java
+++ b/org.eclim.cdt/java/org/eclim/plugin/cdt/command/src/SrcUpdateCommand.java
@@ -17,6 +17,7 @@
 package org.eclim.plugin.cdt.command.src;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 import org.eclim.annotation.Command;
@@ -86,8 +87,7 @@ public class SrcUpdateCommand
 {
   // Taken from org.eclipse.cdt.internal.ui.refactoring.utils.TranslationUnitHelper
   private static final int AST_STYLE =
-    ITranslationUnit.AST_CONFIGURE_USING_SOURCE_CONTEXT |
-    ITranslationUnit.AST_SKIP_INDEXED_HEADERS;
+    ITranslationUnit.AST_CONFIGURE_USING_SOURCE_CONTEXT;
 
   /**
    * {@inheritDoc}
@@ -152,6 +152,18 @@ public class SrcUpdateCommand
       ProblemCollector collector = new ProblemCollector(problems);
       ast.accept(collector);
 
+      String absolutePath = tu.getResource().getLocation().toOSString();
+      for (Iterator<IProblem> iter = problems.iterator();
+    		  iter.hasNext();) {
+    	  IProblem problem = iter.next();
+    	  
+    	  // Remove problems appearing in includes (e.g. Missing ; in file: /usr/include/c++/4.6/bits/stl_algobase.h:732)
+    	  if ( (!(problem instanceof SemanticProblem)) && (!(absolutePath.equals(new String(problem.getOriginatingFileName())))) ) {
+    		  iter.remove();
+    	  }
+    	  
+      }
+      
       return problems;
     } finally {
       if (index != null){


### PR DESCRIPTION
This patch fixes the issue https://github.com/ervandew/eclim/issues/156

We first closed the issue believing that the bug was caused by erroneous project files, but in fact the error comes from the C/C++ indexer.

Indeed as soon as headers containing classes/struct with nested classes/structs declarations get indexed and that implementation file defines these nested structs (e.g. pimpl idiom), eclim begins to gather errors, telling that the nested struct isn't defined because the Translation Unit AST that eclim uses for the validation skips the indexed headers (See https://github.com/ervandew/eclim/issues/156 for an example).

Without this patch the situation  results in vim in errors like  : `Attempt to use symbol failed: impl`, which are inappropriate because the declaration of the nested structs are included and are completely correct.

As I told in my issue comment : https://github.com/ervandew/eclim/issues/156#issuecomment-8953543 , it's possible that this is not the best way to fix the error, and that this is more a workaround than a fix, because I don't know well the AST, but so far this solution works pretty well for me and solved the issue, without changing the error reporting behaviour.
