### PR TITLE
Wrong function name: refreshBundles -> resolveBundles

### DIFF
--- a/org.eclim/java/org/eclim/command/ReloadCommand.java
+++ b/org.eclim/java/org/eclim/command/ReloadCommand.java
@@ -49,7 +49,7 @@ public class ReloadCommand
 
     ArrayList<Bundle> bundles = new ArrayList<Bundle>();
     bundles.add(Platform.getBundle("org.eclim.core"));
-    framework.refreshBundles(bundles);
+    framework.resolveBundles(bundles);
 
     return Services.getMessage("plugins.reloaded");
   }


### PR DESCRIPTION
Got a compilation error when compiling the current code on git:
[javac] org.eclim/java/org/eclim/command/ReloadCommand.java:52: error: method
refreshBundles in interface FrameworkWiring cannot be applied to given types;
[javac]     framework.refreshBundles(bundles);
[javac]              ^
[javac]   required: Collection,FrameworkListener[]
[javac]   found: ArrayList<Bundle>
[javac]   reason: actual and formal argument lists differ in length

According to the javadocs for osgi version 4.3 and 5 (the ones containing the
FrameworkWiring class), the correct function to call with just a
Collection<Bundles> is resolveBundles(Collection<Bundles>)

Reference:
OSGI v5: http://www.osgi.org/javadoc/r5/core/org/osgi/framework/wiring/FrameworkWiring.html
OSGI v4.3: http://www.osgi.org/javadoc/r4v43/core/org/osgi/framework/wiring/FrameworkWiring.html

Tested it on my machine and it was able to compile.
