### PR TITLE
Fix :LocateFile case insensitivity

### DIFF
--- a/org.eclim.core/vim/eclim/autoload/eclim/common/locate.vim
+++ b/org.eclim.core/vim/eclim/autoload/eclim/common/locate.vim
@@ -543,7 +543,7 @@ endfunction " }}}
 function! s:LocateFileCommand(pattern) " {{{
   let command = s:command_locate
   if g:EclimLocateFileCaseInsensitive == 'always' ||
-   \ (a:pattern !~ '[A-Z]' && g:EclimLocateFileCaseInsensitive != 'never')
+   \ (a:pattern !~# '[A-Z]' && g:EclimLocateFileCaseInsensitive != 'never')
     let command .= ' -i'
   endif
   let command .= ' -p "' . a:pattern . '"'


### PR DESCRIPTION
Use the case-sensitive "!~#" operator instead of "!~" when trying to
determine if the search term contains uppercase letters.  The
latter version's results are dependent on the ignorecase option, but
this should always be a case-sensitive match.
