### PR TITLE
Indigo-related changes

### DIFF
--- a/ant/build.gant
+++ b/ant/build.gant
@@ -73,7 +73,13 @@ target(name: 'init'){
     version = version.replaceFirst(/^(\d+\.\d+\.\d+)-(\d+-\w+)$/, '$1.$2')
 
     release = execute('git', 'describe --abbrev=0')
-    release_indigo = execute('git', 'describe --abbrev=0 indigo')
+    try {
+        release_indigo = execute('git', 'describe --abbrev=0 indigo')
+    }
+    catch (ex) {
+        echo('Unable to get indigo release information - do you have an indigo branch?')
+        release_indigo = 'none'
+    }
   }
   property(name: 'eclim.version', value: version)
   property(name: 'eclim.release', value: release)


### PR DESCRIPTION
In 2.2.3 the ant/build.gant file uses git-describe to retrieve the release number from the indigo branch, causing the build to fail when run from a repository that doesn't have the indigo branch checked out.  Commit 540ee67 sets the indigo release string to "none" if an exception is thrown while executing git-describe.

Commit ab35cc9 fixes an Ant variable name used to populate the indigo release number in Vim docs.
