### PR TITLE
Fix :JavaImpl not adding methods from nested classes/interfaces

### DIFF
--- a/org.eclim.jdt/java/org/eclim/plugin/jdt/command/impl/ImplCommand.java
+++ b/org.eclim.jdt/java/org/eclim/plugin/jdt/command/impl/ImplCommand.java
@@ -279,11 +279,16 @@ public class ImplCommand
   private ImplType createImplType(
       ITypeBinding typeBinding, List<String> overridable)
   {
+    String packageName = typeBinding.getPackage().getName();
+    String qualifiedBindingName = typeBinding.getQualifiedName();
+    // Take the remaining part after package name (and following dot) to be the
+    // binding name so as to correctly identify nested classes/interfaces
+    String bindingName = qualifiedBindingName.substring(packageName.length() + 1);
     String signature =
       (typeBinding.isInterface() ? "interface " : "class ") +
-      typeBinding.getName().replaceAll("#RAW", "");
+      bindingName.replaceAll("#RAW", "");
     return new ImplType(
-        typeBinding.getPackage().getName(),
+        packageName,
         signature,
         overridable.toArray(new String[overridable.size()]));
   }


### PR DESCRIPTION
Take the following as an example of the erroneous behaviour

```
public class A {
    public static interface B {
        void onB();
    }
}

public class C implements A.B {
    <type :JavaImpl and select onB()>
}
```

One would expect the skeleton for onB to be added to class C after selecting onB
on the results window. However, nothing happens.

This was due to the fact that
there was a mismatch between the fully-qualified-name (fqn) of the binding and
the superType passed from vim to the eclim eclipse plugin. This mismatch was
created not by vim eclim but by the result returned from the first call to
eclipse eclim to populate the result list where just the package and binding
names would be considered ignoring possible remaining hierarchy on nested types.
