### PR TITLE
build.gant: use ${eclim.plugins} for `ln -s` commands

### DIFF
--- a/ant/build.gant
+++ b/ant/build.gant
@@ -246,10 +246,10 @@ target(name: 'deploy.eclipse'){
       arg(line: '"${eclipse.local}/eclim" "${eclipse.local}/eclimd"')
     }
     exec(executable: 'ln', dir: '${eclipse.local}'){
-      arg(line: '-s plugins/org.eclim_${eclim.version}/bin/eclim .')
+      arg(line: '-s ${eclim.plugins}/org.eclim_${eclim.version}/bin/eclim .')
     }
     exec(executable: 'ln', dir: '${eclipse.local}'){
-      arg(line: '-s plugins/org.eclim_${eclim.version}/bin/eclimd .')
+      arg(line: '-s ${eclim.plugins}/org.eclim_${eclim.version}/bin/eclimd .')
     }
   }
 


### PR DESCRIPTION
I have setup eclim.plugins to use the dropins/ directory instead, and
therefore the creation of the symlinks failed.
