### PR TITLE
Deploy into `dropins`, not `plugins`

### DIFF
--- a/ant/build.gant
+++ b/ant/build.gant
@@ -89,7 +89,7 @@ target(name: 'init'){
   echo('eclim.release.indigo: ${eclim.release.indigo}')
 
   property(name: 'eclim.features', value: '${eclipse.local}/features')
-  property(name: 'eclim.plugins', value: '${eclipse.local}/plugins')
+  property(name: 'eclim.plugins', value: '${eclipse.local}/dropins')
   property(name: 'eclim.home', value: '${eclim.plugins}/org.eclim_${eclim.version}')
 
   // set location of vim files if not already set


### PR DESCRIPTION
I have tried installing/deploying eclim using only ant, without having
used the installer before.

Eclipse did not detect the plugins, until I moved them manually from
plugins/ to dropins/.

I think the ant task (or a new, documented one) should therefore deploy
to dropins instead.

I think it would be better to rename the property / use a different one for the deploy target, instead of letting "plugins" point at "dropins".

This was reported initially as issue #44, with pull request #45.
Both are quite flooded with administrative comments, therefore I create
a new pull request, using a separate branch.
