### PR TITLE
Keep eclim and ng clients in the plugin folder

### DIFF
--- a/ant/build.gant
+++ b/ant/build.gant
@@ -237,7 +237,7 @@ target(name: 'deploy.eclipse'){
   if (Os.isFamily(Os.FAMILY_WINDOWS)){
     move(todir: '${eclipse}'){
       fileset(dir: '${eclim.plugins}/org.eclim_${eclim.version}/bin',
-          includes: 'eclimd.bat,eclimd.cmd,eclim.bat,eclim.cmd,ng.exe')
+          includes: 'eclimd.bat,eclimd.cmd')
     }
   }else{
     delete{


### PR DESCRIPTION
Since commit 3eeacab3, the GetEclimCommand vim function expects eclim.cmd (or eclim.bat) and ng.exe to be in the plugin's bin/ directory instead of the Eclipse root.  Since those files should no longer be moved when deploying on Windows, I think you can revert commit 63cc023f.
