### PR TITLE
Implemented CallHierarchy for Java (caller/callee)

### DIFF
--- a/doc/content/vim/java/inspection.rst
+++ b/doc/content/vim/java/inspection.rst
@@ -57,3 +57,49 @@ Configuration
 - **g:EclimJavaHierarchyDefaultAction** (defaults to 'split') -
   Determines the command used to open the type when hitting <enter> on the type
   entry in the hierarchy buffer.
+
+.. _\:JavaCallHierarchy:
+
+Call Hierarchy
+--------------
+
+When viewing a java source file you can view the call hierarchy of a function
+or method by issuing the command **:JavaCallHierarchy**.  This will open a
+temporary buffer with an inversed tree view of the hierarchy of callers of the
+requested function or method.
+
+.. code-block:: c
+
+  fun2(int)
+     fun1(int)
+       main()
+       fun3(int)
+     fun3(int)
+
+While you are in the hierarchy tree buffer, you can jump to the call under the
+cursor using one of the following key bindings:
+
+- <cr> - open the type using the
+  (:ref:`default action <g:EclimJavaCallHierarchyDefaultAction>`).
+- E - open the type via :edit
+- S - open the type via :split
+- T - open the type via :tabnew
+- ? - view help buffer
+
+**:JavaCallHierarchy** can also be used to view the callees for a function or
+method by invoking the command with a ``!``:
+
+.. code-block:: vim
+
+  :JavaCallHierarchy!
+
+Configuration
+^^^^^^^^^^^^^
+
+:doc:`Vim Settings </vim/settings>`
+
+.. _g\:EclimJavaCallHierarchyDefaultAction:
+
+- **g:EclimJavaCallHierarchyDefaultAction** (defaults to 'split') -
+  Determines the command used to open the file when hitting <enter> on an entry
+  in the hierarchy buffer.

--- a/org.eclim.jdt/java/org/eclim/plugin/jdt/command/hierarchy/CallHierarchyCommand.java
+++ b/org.eclim.jdt/java/org/eclim/plugin/jdt/command/hierarchy/CallHierarchyCommand.java
@@ -1,0 +1,205 @@
+/**
+ * Copyright (C) 2005 - 2013  Eric Van Dewoestine
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.eclim.plugin.jdt.command.hierarchy;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+
+import org.eclim.annotation.Command;
+
+import org.eclim.command.CommandLine;
+import org.eclim.command.Options;
+
+import org.eclim.logging.Logger;
+
+import org.eclim.plugin.jdt.command.search.SearchCommand;
+
+import org.eclim.plugin.jdt.util.JavaUtils;
+
+import org.eclim.util.file.Position;
+
+import org.eclipse.core.resources.IResource;
+
+import org.eclipse.core.runtime.NullProgressMonitor;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IMember;
+import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.ISourceRange;
+
+import org.eclipse.jdt.core.search.SearchEngine;
+
+import org.eclipse.jdt.internal.corext.callhierarchy.CallHierarchy;
+import org.eclipse.jdt.internal.corext.callhierarchy.CallLocation;
+import org.eclipse.jdt.internal.corext.callhierarchy.MethodWrapper;
+
+import org.eclipse.jdt.internal.ui.viewsupport.AppearanceAwareLabelProvider;
+
+import org.eclipse.jdt.ui.JavaElementLabels;
+
+/**
+ * Command to generate a call hierarchy for a method or function.
+ *
+ * @author Alexandre Fonseca
+ */
+@Command(
+  name = "java_callhierarchy",
+  options =
+    "REQUIRED p project ARG," +
+    "REQUIRED f file ARG," +
+    "REQUIRED o offset ARG," +
+    "REQUIRED l length ARG," +
+    "REQUIRED e encoding ARG," +
+    "OPTIONAL c callees NOARG"
+)
+public class CallHierarchyCommand
+  extends SearchCommand
+{
+  private static final String CALLEES_OPTION = "c";
+  private static final int MAX_CALL_DEPTH = 3;
+  private static Logger logger = Logger.getLogger(CallHierarchyCommand.class);
+
+  @Override
+  public Object execute(CommandLine commandLine)
+    throws Exception
+  {
+    HashMap<String,Object> result  = new HashMap<String, Object>();
+
+    try {
+      String project = commandLine.getValue(Options.PROJECT_OPTION);
+      String file = commandLine.getValue(Options.FILE_OPTION);
+      boolean callees = commandLine.hasOption(CALLEES_OPTION);
+      int offset = getOffset(commandLine);
+
+      ICompilationUnit src = JavaUtils.getCompilationUnit(project, file);
+
+      IJavaElement element = src.getElementAt(offset);
+
+      if (element instanceof IMethod) {
+        IMethod method = (IMethod) element;
+        IMember[] members = new IMember[]{method};
+        MethodWrapper[] roots;
+
+        CallHierarchy callHierarchy = CallHierarchy.getDefault();
+        // Keep search scope for hierarchy in current project
+        callHierarchy.setSearchScope(
+          SearchEngine.createJavaSearchScope(new IJavaElement[] {
+            src.getJavaProject(),
+          }));
+
+        Comparator<MethodWrapper> comparator = null;
+        
+        if (callees) {
+          roots = callHierarchy.getCalleeRoots(members);
+        } else {
+          roots = callHierarchy.getCallerRoots(members);
+          // Following Eclipse's GUI, callers are ordered
+          // alphabetically, callees by position in function.
+          comparator = new Comparator<MethodWrapper>() {
+            public int compare(MethodWrapper o1, MethodWrapper o2) {
+              return o1.getName().compareToIgnoreCase(o2.getName());
+            }
+          };
+        }
+
+        if (roots.length > 0) {
+          // Is it possible to have multiple roots? If so we'll need
+          // to change this.
+          result = formatRoot(roots[0], comparator);
+
+          IResource resource = method.getResource();
+          ISourceRange sourceRange = method.getSourceRange();
+          // The root element doesn't get his location like all the others
+          // (this happens with the GUI too). So add it ourselves.
+          result.put("position", Position.fromOffset(
+                resource.getLocation().toOSString(), null, sourceRange.getOffset(),
+                sourceRange.getLength()));
+        }
+      }
+    } catch (Exception e) {
+      StringWriter sw = new StringWriter();
+      PrintWriter pw = new PrintWriter(sw);
+      e.printStackTrace(pw);
+      logger.error(e.getMessage() + "\n" + sw.toString());
+    }
+
+      return result;
+  }
+
+  private ArrayList<HashMap<String,Object>> formatRoots(
+      MethodWrapper[] roots, Comparator<MethodWrapper> comparator)
+    throws Exception
+  {
+    ArrayList<HashMap<String,Object>> results =
+      new ArrayList<HashMap<String,Object>>();
+
+    if (comparator != null) {
+      Arrays.sort(roots, comparator);
+    }
+
+    for (MethodWrapper root : roots) {
+      if (root.getLevel() > MAX_CALL_DEPTH || root.isRecursive()) {
+        continue;
+      }
+      results.add(formatRoot(root, comparator));
+    }
+
+    return results;
+  }
+
+  private HashMap<String, Object> formatRoot(MethodWrapper root,
+      Comparator<MethodWrapper> comparator)
+    throws Exception
+  {
+    IMember member = root.getMember();
+    String memberName = JavaElementLabels.getTextLabel(member, 
+        AppearanceAwareLabelProvider.DEFAULT_TEXTFLAGS | 
+        JavaElementLabels.ALL_POST_QUALIFIED |
+        JavaElementLabels.P_COMPRESSED);
+    CallLocation location = root.getMethodCall().getFirstCallLocation();
+
+    HashMap<String,Object> result = new HashMap<String, Object>();
+    result.put("name", memberName);
+
+    if (location != null) {
+      // If caller, locationMember == member. If callee, locationMember
+      // is the function where the callee is called.
+      IMember locationMember = location.getMember();
+      IResource resource = locationMember.getResource();
+
+      if (resource != null) {
+        String file = resource.getLocation().toOSString().replace('\\', '/');
+        int offset = location.getStart();
+
+        result.put("position", Position.fromOffset(file, null, offset, 
+            location.getEnd() - offset));
+      }
+    }
+
+    result.put("callers", formatRoots(
+          root.getCalls(new NullProgressMonitor()),
+          comparator));
+
+    return result;
+  }
+}

--- a/org.eclim.jdt/test/eclim_unit_test_java/src/org/eclim/test/hierarchy/TestCallHierarchy.java
+++ b/org.eclim.jdt/test/eclim_unit_test_java/src/org/eclim/test/hierarchy/TestCallHierarchy.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2005 - 2013  Eric Van Dewoestine
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.eclim.test.hierarchy;
+
+public class TestCallHierarchy {
+
+  void foo() {
+    SubClass subClassInstance = this.new SubClass();
+    subClassInstance.bar();
+    subClassInstance.barWithStuff(new Object());
+    SweetDreams dreams = TestCallHierarchyExternal.getEurythmics();
+    Object this = dreams.areMadeOf();
+  }
+
+  private class SubClass {
+    void bar() {
+    }
+
+    Object barWithStuff(Object stuff) {
+      TestCallHierarchyExternal.getEurythmics();
+      return stuff;
+    }
+  }
+}

--- a/org.eclim.jdt/test/eclim_unit_test_java/src/org/eclim/test/hierarchy/TestCallHierarchyExternal.java
+++ b/org.eclim.jdt/test/eclim_unit_test_java/src/org/eclim/test/hierarchy/TestCallHierarchyExternal.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) 2005 - 2013  Eric Van Dewoestine
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.eclim.test.hierarchy;
+
+public class TestCallHierarchyExternal {
+  public static SweetDreams getEurythmics() {
+    return new SweetDreams();
+  }
+
+  public static class SweetDreams {
+    public void areMadeOf() {
+      return this;
+    }
+  }
+}

--- a/org.eclim.jdt/test/junit/org/eclim/plugin/jdt/command/hierarchy/CallHierarchyCommandTest.java
+++ b/org.eclim.jdt/test/junit/org/eclim/plugin/jdt/command/hierarchy/CallHierarchyCommandTest.java
@@ -1,0 +1,157 @@
+/**
+ * Copyright (C) 2005 - 2013  Eric Van Dewoestine
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.eclim.plugin.jdt.command.hierarchy;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclim.Eclim;
+
+import org.eclim.plugin.jdt.Jdt;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test case for CallHierarchyCommand.
+ *
+ * @author Alexandre Fonseca
+ */
+public class CallHierarchyCommandTest
+{
+  private static final String TEST_FILE_CALLEES = "src/hierarchy/TestHierarchy";
+  private static final String TEST_FILE_CALLERS = 
+    "src/hierarchy/TestHierarchyExternal";
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void executeCallers()
+  {
+    assertTrue("Project doesn't exist.",
+        Eclim.projectExists(Jdt.TEST_PROJECT));
+
+    // reference to fun2
+    Map<String,Object> result = (Map<String,Object>)
+      Eclim.execute(new String[]{
+        "java_callhierarchy", "-p", Jdt.TEST_PROJECT, "-f", TEST_FILE_CALLERS,
+        "-o", "850", "-l", "22", "-e", "utf-8",
+      });
+
+    String path = Eclim.getProjectPath(Jdt.TEST_PROJECT) + "/src/hierarchy/";
+
+    Map<String,Object> position = (Map<String,Object>)result.get("position");
+    List<Map<String,Object>> calls =
+      (List<Map<String,Object>>)result.get("callers");
+    assertEquals(result.get("name"), "getEurythmics() : SweetDreams" +
+        " - org.eclim.test.hierarchy.TestCallHierarchyExternal");
+    assertEquals(path + "TestCallHierarchyExternal.java", position.get("filename"));
+    assertEquals(21, position.get("line"));
+    assertEquals(3, position.get("column"));
+    assertEquals(2, calls.size());
+
+    result = calls.get(0);
+    position = (Map<String,Object>)result.get("position");
+    List<Map<String,Object>> nestedCalls =
+      (List<Map<String,Object>>)result.get("callers");
+    assertEquals(result.get("name"), "barWithStuff(Object) : Object" +
+        " - org.eclim.test.hierarchy.TestCallHierarchy");
+    assertEquals(path + "TestCallHierarchy.java", position.get("filename"));
+    assertEquals(35, position.get("line"));
+    assertEquals(7, position.get("column"));
+    assertEquals(1, nestedCalls.size());
+
+    result = nestedCalls.get(0);
+    position = (Map<String,Object>)result.get("position");
+    assertEquals(result.get("name"), "foo() : void" +
+        " - org.eclim.test.hierarchy.TestCallHierarchy");
+    assertEquals(path + "TestCallHierarchy.java", position.get("filename"));
+    assertEquals(25, position.get("line"));
+    assertEquals(5, position.get("column"));
+
+    result = calls.get(1);
+    position = (Map<String,Object>)result.get("position");
+    assertEquals(result.get("name"), "foo() : void" +
+        " - org.eclim.test.hierarchy.TestCallHierarchy");
+    assertEquals(path + "TestCallHierarchy.java", position.get("filename"));
+    assertEquals(26, position.get("line"));
+    assertEquals(27, position.get("column"));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void executeCallees()
+  {
+    assertTrue("Project doesn't exist.",
+        Eclim.projectExists(Jdt.TEST_PROJECT));
+
+    Map<String,Object> result = (Map<String,Object>)
+      Eclim.execute(new String[]{
+        "java_callhierarchy", "-p", Jdt.TEST_PROJECT, "-f", TEST_FILE_CALLEES,
+        "-o", "790", "-l", "22", "-e", "utf-8", "-c"
+      });
+
+    String path = Eclim.getProjectPath(Jdt.TEST_PROJECT) + "/src/hierarchy/";
+
+    Map<String,Object> position = (Map<String,Object>)result.get("position");
+    List<Map<String,Object>> calls =
+      (List<Map<String,Object>>)result.get("callers");
+    assertEquals(result.get("name"), "foo() : void" +
+        " - org.eclim.test.hierarchy.TestCallHierarchy");
+    assertEquals(path + "TestCallHierarchy.java", position.get("filename"));
+    assertEquals(22, position.get("line"));
+    assertEquals(3, position.get("column"));
+    assertEquals(3, calls.size());
+
+    result = calls.get(0);
+    List<Map<String,Object>> nestedCalls =
+      (List<Map<String,Object>>)result.get("callers");
+    position = (Map<String,Object>)result.get("position");
+    assertEquals(result.get("name"), "SubClass()" +
+        " - org.eclim.test.hierarchy.TestCallHierarchy.SubClass");
+    assertEquals(path + "TestCallHierarchy.java", position.get("filename"));
+    assertEquals(23, position.get("line"));
+    assertEquals(42, position.get("column"));
+    assertEquals(0, nestedCalls.size());
+
+    result = calls.get(1);
+    position = (Map<String,Object>)result.get("position");
+    assertEquals(result.get("name"), "bar() : void" +
+        " - org.eclim.test.hierarchy.TestCallHierarchy.SubClass");
+    assertEquals(path + "TestCallHierarchy.java", position.get("filename"));
+    assertEquals(24, position.get("line"));
+    assertEquals(5, position.get("column"));
+
+    result = calls.get(2);
+    nestedCalls = (List<Map<String, Object>>) result.get("callers");
+    position = (Map<String,Object>)result.get("position");
+    assertEquals(result.get("name"), "barWithStuff(Object) : Object" + 
+        " - org.eclim.test.hierarchy.TestCallHierarchy.SubClass");
+    assertEquals(path + "TestCallHierarchy.java", position.get("filename"));
+    assertEquals(25, position.get("line"));
+    assertEquals(5, position.get("column"));
+    assertEquals(1, nestedCalls.size());
+
+    result = nestedCalls.get(0);
+    position = (Map<String,Object>)result.get("position");
+    assertEquals(result.get("name"), "getEurythmics() : SweetDreams" + 
+        " - org.eclim.test.hierarchy.TestCallHierarchyExternal");
+    assertEquals(path + "TestCallHierarchy.java", position.get("filename"));
+    assertEquals(35, position.get("line"));
+    assertEquals(7, position.get("column"));
+  }
+}

--- a/org.eclim.jdt/vim/eclim/autoload/eclim/java/callhierarchy.vim
+++ b/org.eclim.jdt/vim/eclim/autoload/eclim/java/callhierarchy.vim
@@ -1,0 +1,147 @@
+" Author:  Eric Van Dewoestine
+"
+" Description: {{{
+"   see http://eclim.org/vim/c/hierarchy.html
+"
+" License:
+"
+" Copyright (C) 2005 - 2013  Eric Van Dewoestine
+"
+" This program is free software: you can redistribute it and/or modify
+" it under the terms of the GNU General Public License as published by
+" the Free Software Foundation, either version 3 of the License, or
+" (at your option) any later version.
+"
+" This program is distributed in the hope that it will be useful,
+" but WITHOUT ANY WARRANTY; without even the implied warranty of
+" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+" GNU General Public License for more details.
+"
+" You should have received a copy of the GNU General Public License
+" along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"
+" }}}
+
+" Global Variables {{{
+if !exists('g:EclimJavaCallHierarchyDefaultAction')
+  let g:EclimJavaCallHierarchyDefaultAction = g:EclimDefaultFileOpenAction
+endif
+" }}}
+
+" Script Variables {{{
+  let s:call_hierarchy =
+    \ '-command java_callhierarchy -p "<project>" -f "<file>" ' .
+    \ '-o <offset> -l <length> -e <encoding>'
+" }}}
+
+function! eclim#java#callhierarchy#CallHierarchy(bang) " {{{
+  if !eclim#project#util#IsCurrentFileInProject(1)
+    return
+  endif
+
+  call eclim#lang#SilentUpdate()
+
+  let project = eclim#project#util#GetCurrentProjectName()
+  let file = eclim#project#util#GetProjectRelativeFilePath()
+  let position = eclim#util#GetCurrentElementPosition()
+  let offset = substitute(position, '\(.*\);\(.*\)', '\1', '')
+  let length = substitute(position, '\(.*\);\(.*\)', '\2', '')
+  let command = s:call_hierarchy
+  let command = substitute(command, '<project>', project, '')
+  let command = substitute(command, '<file>', file, '')
+  let command = substitute(command, '<offset>', offset, '')
+  let command = substitute(command, '<length>', length, '')
+  let command = substitute(command, '<encoding>', eclim#util#GetEncoding(), '')
+  " return callees
+  if a:bang != ''
+    let command .= ' -c'
+  endif
+
+  let result = eclim#Execute(command)
+  if type(result) != g:DICT_TYPE
+    return
+  endif
+
+  if len(result) == 0
+    call eclim#util#Echo('No results found.')
+    return
+  endif
+
+  let lines = []
+  let info = []
+  let key = 'callers'
+  call s:CallHierarchyFormat(result, key, lines, info, '')
+
+  call eclim#util#TempWindow('[Call Hierarchy]', lines)
+  set ft=c
+  " fold function calls into their parent
+  setlocal foldmethod=expr
+  setlocal foldexpr='>'.len(substitute(getline(v:lnum),'^\\(\\s*\\).*','\\1',''))/2
+  setlocal foldtext=substitute(getline(v:foldstart),'^\\(\\s*\\)\\s\\s','\\1+\ ','').':\ '.(v:foldend-v:foldstart+1).'\ lines'
+
+  setlocal modifiable noreadonly
+  call append(line('$'), ['', '" use ? to view help'])
+  setlocal nomodifiable readonly
+  syntax match Comment /^".*/
+
+  let b:hierarchy_info = info
+
+  nnoremap <buffer> <silent> <cr>
+    \ :call <SID>Open(g:EclimJavaCallHierarchyDefaultAction)<cr>
+  nnoremap <buffer> <silent> E :call <SID>Open('edit')<cr>
+  nnoremap <buffer> <silent> S :call <SID>Open('split')<cr>
+  nnoremap <buffer> <silent> T :call <SID>Open("tablast \| tabnew")<cr>
+
+  " assign to buffer var to get around weird vim issue passing list containing
+  " a string w/ a '<' in it on execution of mapping.
+  let b:hierarchy_help = [
+      \ '<cr> - open file with default action',
+      \ 'E - open with :edit',
+      \ 'S - open in a new split window',
+      \ 'T - open in a new tab',
+    \ ]
+  nnoremap <buffer> <silent> ?
+    \ :call eclim#help#BufferHelp(b:hierarchy_help, 'vertical', 40)<cr>
+endfunction " }}}
+
+function! s:CallHierarchyFormat(result, key, lines, info, indent) " {{{
+  if has_key(a:result, 'position')
+    call add(a:info, {
+        \ 'file': a:result.position.filename,
+        \ 'line': a:result.position.line,
+        \ 'col': a:result.position.column
+      \ })
+    call add(a:lines, a:indent . a:result.name)
+  else
+    call add(a:info, {'file': '', 'line': -1, 'col': -1})
+    call add(a:lines, a:indent . a:result.name)
+  endif
+
+  for call in get(a:result, a:key, [])
+    call s:CallHierarchyFormat(call, a:key, a:lines, a:info, a:indent . "\t")
+  endfor
+endfunction " }}}
+
+function! s:Open(action) " {{{
+  let line = line('.')
+  if line > len(b:hierarchy_info)
+    return
+  endif
+
+  let info = b:hierarchy_info[line - 1]
+  if info.file != ''
+    " go to the buffer that initiated the hierarchy
+    exec b:winnr . 'winc w'
+
+    let action = a:action
+    call eclim#util#GoToBufferWindowOrOpen(info.file, action)
+    call cursor(info.line, info.col)
+
+   " force any previous messge from else below to be cleared
+    echo ''
+  else
+    call eclim#util#Echo('No associated file was found.')
+  endif
+endfunction " }}}
+
+" vim:ft=vim:fdm=marker

--- a/org.eclim.jdt/vim/eclim/ftplugin/java.vim
+++ b/org.eclim.jdt/vim/eclim/ftplugin/java.vim
@@ -203,6 +203,10 @@ if !exists(":JavaDocSearch")
     \ JavaDocSearch :call eclim#java#search#SearchAndDisplay('java_docsearch', '<args>')
 endif
 
+if !exists(":JavaCallHierarchy")
+  command -buffer -bang JavaCallHierarchy :call eclim#java#callhierarchy#CallHierarchy('<bang>')
+endif
+
 if !exists(":JavaHierarchy")
   command -buffer -range JavaHierarchy :call eclim#java#hierarchy#Hierarchy()
 endif


### PR DESCRIPTION
Closes #134.

Included eclim command, vim scripts, vim documentation and some attempt
at testing. Ran checkstyle.

I was unable to run the tests as no matter what target I used for ant,
it constantly tried to overwrite files in my eclipse folder. Will try
to look at it again with more attention tomorrow. In any case, I tested
manually around the eclim source code and it appears to be working.

I based the code on C's CallHierarchy. I left the maximum depth at 3
since that's what appeared on the C example but I think it would make
more sense to set it at 2 because with big projects it takes quite some
time (up to 5 seconds on the execute method of the implemented 
command in eclipse). We could then employ a system on the vimscript 
to ask for more call hierarchy on a particular element like what is done in 
the GUI. I'm not very experienced with VimScript but it seems doable 
(code similar to NerdTree, etc) and would bring it closer to the Eclipse 
GUI behaviour and performance.
