### PR TITLE
Added options to tool and help windows.

### DIFF
--- a/org.eclim.core/vim/eclim/autoload/eclim/display/window.vim
+++ b/org.eclim.core/vim/eclim/autoload/eclim/display/window.vim
@@ -121,6 +121,7 @@ function! eclim#display#window#VerticalToolWindowOpen(name, weight, ...) " {{{
   doautocmd BufWinEnter
   setlocal winfixwidth
   setlocal nonumber
+  setlocal nospell norelativenumber
 
   let b:weight = a:weight
   let bufnum = bufnr('%')

--- a/org.eclim.core/vim/eclim/autoload/eclim/help.vim
+++ b/org.eclim.core/vim/eclim/autoload/eclim/help.vim
@@ -117,6 +117,7 @@ function! eclim#help#BufferHelp(lines, orientation, size)
   endif
   setlocal nowrap
   setlocal noswapfile nobuflisted nonumber
+  setlocal nospell norelativenumber
   setlocal buftype=nofile bufhidden=delete
   nnoremap <buffer> <silent> ? :bd<cr>
   nnoremap <buffer> <silent> q :bd<cr>


### PR DESCRIPTION
If user has spell option enabled by default then it should be disabled in tool and help windows. Spelling check doesn't make sense on project/file names or keybindings.
Relative numbering should be disabled as it was done with usual numbering since they have different settings.
