### PR TITLE
Added a plugin whitelist property to control what plugins to install.

### DIFF
--- a/ant/build.gant
+++ b/ant/build.gant
@@ -823,6 +823,13 @@ def initPlugins(){
   names = []
   features = []
   exclude = ['org.eclim.installer']
+
+  pluginWhiteList = []
+  pluginWhiteListStr = getVariable('plugin.whitelist')
+  if (pluginWhiteListStr) {
+    pluginWhiteList += pluginWhiteListStr.tokenize(',')
+  }
+
   defaults = ['org.eclim', 'org.eclim.core', 'org.eclim.vimplugin']
   defaults.each{ name -> pluginInclude(name)}
 
@@ -863,6 +870,10 @@ def initPlugins(){
   new File('.').eachDirMatch(~/org\.eclim\.\w*/){ dir ->
     name = dir.getName()
     if (!exclude.contains(name) && !defaults.contains(name)){
+      if (pluginWhiteList.size() > 0 && !pluginWhiteList.contains(name)) {
+        ant.echo("# Skipping ${name} since it's not in whitelist")
+        return
+      }
       pluginInclude(name)
       feature = getVariable("feature_${shortName}")
       if (!feature || features.contains(feature)){


### PR DESCRIPTION
While I have most Eclipse language plugins (pdt, cdt, etc...) installed,
I actually prefer YCM+Syntastic for some of those (Python, C++). With
this property I can just say:

-Dplugin.whitelist=org.eclim.jdt,org.eclim.adt

To only install the java plugins.

I remember that a similar functionality was once on the build scripts
but I was unable to find it with the current ones. If I just missed it, feel
free to reject the pull ;)
