### PR TITLE
Possiblity to open buffers in vertical splits with V in :Buffers

### DIFF
--- a/org.eclim.core/vim/eclim/autoload/eclim/common/buffers.vim
+++ b/org.eclim.core/vim/eclim/autoload/eclim/common/buffers.vim
@@ -92,6 +92,7 @@ function! eclim#common#buffers#Buffers(bang) " {{{
   nnoremap <silent> <buffer> <cr> :call <SID>BufferOpen(g:EclimBuffersDefaultAction)<cr>
   nnoremap <silent> <buffer> E :call <SID>BufferOpen('edit')<cr>
   nnoremap <silent> <buffer> S :call <SID>BufferOpen('split')<cr>
+  nnoremap <silent> <buffer> V :call <SID>BufferOpen('vsplit')<cr>
   nnoremap <silent> <buffer> T :call <SID>BufferOpen('tablast \| tabnew')<cr>
   nnoremap <silent> <buffer> D :call <SID>BufferDelete()<cr>
   nnoremap <silent> <buffer> R :Buffers<cr>


### PR DESCRIPTION
Hi,

Just a one line addition to allow opening buffers in vertical splits using 'V' with the ':Buffers' view. Using wide screens and short lines of code, I tend to prefer vertical splits to horizontal ones.

Cheers,
Yoann.
