### PR TITLE
TBD: Refactor syntastic deactivation / fix for EclimFileTypeValidate=0

### DIFF
--- a/org.eclim.core/vim/eclim/autoload/eclim/lang.vim
+++ b/org.eclim.core/vim/eclim/autoload/eclim/lang.vim
@@ -225,16 +225,29 @@ function! eclim#lang#Search(command, singleResultAction, argline)
 
 endfunction " }}}
 
+function! eclim#lang#isFiletypeValidationEnabled(lang) " {{{
+    " global setting
+    if !g:EclimFileTypeValidate
+      return 0
+    endif
+    " per lang setting
+    exec 'let validate = g:Eclim' . toupper(a:lang[0]) . a:lang[1:] . 'Validate'
+    return validate
+endfunction " }}}
+
+function! eclim#lang#disableSyntasticIfValidationIsEnabled(lang) " {{{
+  if exists('g:loaded_syntastic_plugin') && eclim#lang#isFiletypeValidationEnabled(a:lang)
+    exec 'let validate = g:syntastic_' . tolower(a:lang) . '_checkers = []'
+  endif
+endfunction " }}}
+
 function! eclim#lang#UpdateSrcFile(lang, ...) " {{{
   " Updates the src file on the server w/ the changes made to the current file.
   " Optional arg:
   "   validate: when 1 force the validation to execute, when 0 prevent it.
 
   if !a:0
-    " per lang setting
-    exec 'let validate = g:Eclim' . toupper(a:lang[0]) . a:lang[1:] . 'Validate'
-    " global setting
-    let validate = validate && g:EclimFileTypeValidate
+    let validate = eclim#lang#isFiletypeValidationEnabled(lang)
   else
     " arg override
     let validate = a:1

--- a/org.eclim.pdt/vim/eclim/ftplugin/php.vim
+++ b/org.eclim.pdt/vim/eclim/ftplugin/php.vim
@@ -42,10 +42,7 @@ endif
 
 exec 'setlocal ' . g:EclimCompletionMethod . '=eclim#php#complete#CodeComplete'
 
-" disable syntastic
-if exists('g:loaded_syntastic_plugin') && !g:EclimPhpSyntasticEnabled
-  let g:syntastic_php_checkers = []
-endif
+call eclim#lang#disableSyntasticIfValidationIsEnabled('php')
 
 " }}}
 


### PR DESCRIPTION
Add eclim#lang#isFiletypeValidationEnabled and
eclim#lang#disableSyntasticIfValidationIsEnabled and call the latter
from filetype files.

TODO: this commit contains the change for php.vim only, but should get
used for the other filetypes, when accepted.

This pull request is meant for discussion - feel free to adopt it as you see it fits, or tell me how to change it.

The issue I had was that I ended up debugging Syntastic, trying to find out why the list of checkers ended up empty. It turned out that eclim forcefully set it, although I am using `g:EclimFileTypeValidate=0`.
