### PR TITLE
Don't clobber alternate file when writing tempfile

### DIFF
--- a/org.eclim.core/vim/eclim/autoload/eclim/lang.vim
+++ b/org.eclim.core/vim/eclim/autoload/eclim/lang.vim
@@ -351,7 +351,7 @@ function! eclim#lang#SilentUpdate(...) " {{{
           if a:0 < 2 || a:2
             let savepatchmode = &patchmode
             set patchmode=
-            exec 'silent noautocmd write! ' . escape(tempfile, ' ')
+            exec 'silent noautocmd keepalt write! ' . escape(tempfile, ' ')
             let &patchmode = savepatchmode
           endif
         endif


### PR DESCRIPTION
Without this the alternate file gets replaced by an empty temporary file, which is quite annoying.
