### PR TITLE
Two minor improvements to Django SQL dialect handling

### DIFF
--- a/org.eclim.pydev/vim/eclim/autoload/eclim/python/django/manage.vim
+++ b/org.eclim.pydev/vim/eclim/autoload/eclim/python/django/manage.vim
@@ -111,7 +111,7 @@ function! eclim#python#django#manage#Manage(args) " {{{
     else
       let path = eclim#python#django#util#GetProjectPath()
       let engine = eclim#python#django#util#GetSqlEngine(path)
-      let dialect = has_key(s:sql_dialects, engine) ? s:sql_dialects[engine] : 'plsql'
+      let dialect = has_key(s:sql_dialects, engine) ? s:sql_dialects[engine] : 'plsql.vim'
 
       let filename = expand('%')
       let name = '__' . action . '__'


### PR DESCRIPTION
I have noticed that `s:sql_dialects` got trimmed when switching to pydev, but I had the addition of "oracle" still in a local stash.
