### PR TITLE
NAILGUN_SERVER interferes with Eclim's Vim plugin/Nailgun client operation

### DIFF
--- a/org.eclim.core/vim/eclim/autoload/eclim/client/nailgun.vim
+++ b/org.eclim.core/vim/eclim/autoload/eclim/client/nailgun.vim
@@ -129,7 +129,7 @@ function! eclim#client#nailgun#Execute(instance, command, ...) " {{{
     let command = substitute(command, '\^', '^^', 'g')
   endif
 
-  let eclim = result . ' --nailgun-port ' . a:instance.port . ' ' . command
+  let eclim = result . ' --nailgun-server localhost --nailgun-port ' . a:instance.port . ' ' . command
   if exec
     let eclim = '!' . eclim
   endif


### PR DESCRIPTION
Eclim is basically an embedded Nailgun server that the Vim plugin connects to to execute commands in the Eclipse environment. I happen to use Nailgun for another project and rely on the environment variable `NAILGUN_SERVER` to point my Nailgun client to the appropriate server I need to talk to. Unfortunately this interferes with the Vim plugin; when I start Vim from a shell in which I set this variable (which is basically 100% of the time), the plugin cannot connect to the Eclim daemon because it tries to talk to the wrong host. If I `unset NAILGUN_SERVER` before starting Vim, all is good again.

This is because, by default, Eclim will use the `external` Eclim client, which points to the Nailgun client binary provided as part of the Eclipse plugin. This client interprets the `NAILGUN_SERVER` which lands us at an incorrect destination.

There are two ways to solve this:
1. Adding `let g:EclimNailgunClient = 'python'` to the `.vimrc` to force the use of the Python client that hardcodes `localhost` as the target host, or
2. Adding `--nailgun-server` to the prepared Nailgun command so that, when using the external client, the plugin always contacts the correct Nailgun server (that is, the Eclim daemon).

This change request implements this second point.
