### PR TITLE
ECLIPSE_LAUNCHER might contain multiple lines: use the most recent one

### DIFF
--- a/org.eclim/bin/eclimd
+++ b/org.eclim/bin/eclimd
@@ -73,7 +73,9 @@ resolve_eclipse_launcher(){
     ECLIM_ECLIPSE_HOME=`cd "$ECLIM_HOME/../../"; pwd`
   fi
 
-  ECLIPSE_LAUNCHER=`find "$ECLIM_ECLIPSE_HOME/plugins" -name 'org.eclipse.equinox.launcher_*.jar'`
+  # Find the least modified launcher.
+  ECLIPSE_LAUNCHER=`find "$ECLIM_ECLIPSE_HOME/plugins" \
+    -name 'org.eclipse.equinox.launcher_*.jar' -exec ls -1t "{}" + | head -n1`
 
   if [ ! -e "$ECLIPSE_LAUNCHER" ]; then
     echo "Unable to locate the eclipse launcher jar." 1>&2


### PR DESCRIPTION
After upgrading to Eclipse 4.4, I've ended up with:

> find /opt/eclipse/plugins -name 'org.eclipse.equinox.launcher_*.jar'
>   /opt/eclipse/plugins/org.eclipse.equinox.launcher_1.3.0.v20140415-2008.jar
>   /opt/eclipse/plugins/org.eclipse.equinox.launcher_1.3.0.v20130327-1440.jar

This results in "Unable to locate the eclipse launcher jar.", because
the `test -e` fails.
