### PR TITLE
Allow users to choose between 0 and 1 based lists for prompts.

### DIFF
--- a/doc/content/vim/core/eclim.rst
+++ b/doc/content/vim/core/eclim.rst
@@ -205,3 +205,9 @@ The following is a list of some of the common Vim variables available.
 
   When set to a non-0 value, enabled auto generation of gvim menus (under
   Plugin.eclim) for each eclim command available for the current buffer.
+
+.. _g\:EclimPromptListStartValue:
+
+- ** g:EclimPromptListStartValue (Default: 0)
+
+  Will create 0 or 1 based list when the user is prompted for a choice.

--- a/org.eclim.core/vim/eclim/autoload/eclim/util.vim
+++ b/org.eclim.core/vim/eclim/autoload/eclim/util.vim
@@ -989,11 +989,12 @@ function! eclim#util#PromptList(prompt, list, ...)
   endif
 
   let prompt = ""
-  let index = 0
+  let index = g:EclimPromptListStartValue
   for item in a:list
     let prompt = prompt . index . ") " . item . "\n"
     let index = index + 1
   endfor
+  let maxindex = index - 1
 
   exec "echohl " . (a:0 ? a:1 : g:EclimHighlightInfo)
   try
@@ -1008,10 +1009,11 @@ function! eclim#util#PromptList(prompt, list, ...)
       let response = input(a:prompt . ": ")
     endtry
     while response !~ '\(^$\|^[0-9]\+$\)' ||
-        \ response < 0 ||
-        \ response > (len(a:list) - 1)
+        \ response < g:EclimPromptListStartValue ||
+        \ response > maxindex
       let response = input("You must choose a value between " .
-        \ 0 . " and " . (len(a:list) - 1) . ". (Ctrl-C to cancel): ")
+        \ g:EclimPromptListStartValue . " and " . maxindex .
+        \ ". (Ctrl-C to cancel): ")
     endwhile
   finally
     echohl None
@@ -1022,7 +1024,7 @@ function! eclim#util#PromptList(prompt, list, ...)
     return -1
   endif
 
-  return response
+  return response - g:EclimPromptListStartValue
 endfunction " }}}
 
 " PromptConfirm(prompt, [highlight]) {{{

--- a/org.eclim.core/vim/eclim/plugin/eclim.vim
+++ b/org.eclim.core/vim/eclim/plugin/eclim.vim
@@ -115,6 +115,11 @@ call eclim#AddVimSetting(
   \ '\d\+')
 
 call eclim#AddVimSetting(
+  \ 'Core', 'g:EclimPromptListStartValue', 0,
+  \ 'The start value for list prompts.',
+  \ '\(0\|1\)')
+
+call eclim#AddVimSetting(
   \ 'Core', 'g:EclimMakeLCD', 1,
   \ "When set to a non-0 value, all eclim based make commands\n" .
   \ "(:Ant, :Maven, :Mvn, etc) will change to the current file's\n" .


### PR DESCRIPTION
I added a variable `g:EclimPromptListStartValue` to let users choose between 0 and 1 based lists when using `eclim#util#PromptList`.

When running `eclim#util#PromptList("prompt", ['a', 'b'])` the user would be shown the following if `g:EclimPromptListStartValue = 0`

```
0) a
1) b

prompt:
```

And this when `g:EclimPromptListStartValue = 1`

```
1) a
2) b

prompt: 
```
