### PR TITLE
vim: do not `expand()` shell vars

### DIFF
--- a/org.eclim.core/vim/eclim/autoload/eclim.vim
+++ b/org.eclim.core/vim/eclim/autoload/eclim.vim
@@ -551,11 +551,12 @@ function! eclim#SaveVimSettings() " {{{
 endfunction " }}}
 
 function! eclim#UserHome() " {{{
-  let home = expand('$HOME')
   if has('win32unix')
     let home = eclim#cygwin#WindowsHome()
   elseif has('win32') || has('win64')
     let home = expand('$USERPROFILE')
+  else
+    let home = $HOME
   endif
   return substitute(home, '\', '/', 'g')
 endfunction " }}}

--- a/org.eclim.core/vim/eclim/plugin/eclim.vim
+++ b/org.eclim.core/vim/eclim/plugin/eclim.vim
@@ -258,11 +258,12 @@ endif
 let g:EclimQuote = "['\"]"
 
 if !exists("g:EclimTempDir")
-  let g:EclimTempDir = expand('$TMP')
-  if g:EclimTempDir == '$TMP'
-    let g:EclimTempDir = expand('$TEMP')
-  endif
-  if g:EclimTempDir == '$TEMP' && has('unix')
+  " NOTE: `expand("$FOO")` might spawn a new shell.
+  if len($TMP)
+    let g:EclimTempDir = $TMP
+  elseif len($TEMP)
+    let g:EclimTempDir = $TEMP
+  elseif has('unix')
     let g:EclimTempDir = '/tmp'
   endif
 

--- a/org.eclim.dltkruby/vim/eclim/autoload/eclim/ruby/project.vim
+++ b/org.eclim.dltkruby/vim/eclim/autoload/eclim/ruby/project.vim
@@ -47,7 +47,7 @@ function s:InitInterpreters() " {{{
       silent! let path =
         \ substitute(eclim#util#System('which ruby 2> /dev/null'), '\n$', '', '')
     else
-      let paths = escape(substitute(expand('$PATH'), ';', ',', 'g'), ' ')
+      let paths = escape(substitute($PATH, ';', ',', 'g'), ' ')
       let path = substitute(findfile('ruby.exe', paths, ';'), '\', '/', 'g')
     endif
     let answer = 0


### PR DESCRIPTION
This is especially important when testing for variables like `$TMP`: if
they do not exist, a new shell is started to look for them, although
shell variables are provided already in Vim.

I might be missing something here, e.g. regarding Windows support!

See also: http://www.reddit.com/r/vim/comments/2el2zo/til_expandshellvar_might_spawn_a_shell/
