### PR TITLE
Match `{% endblock foo %}` with b:match_words

### DIFF
--- a/org.eclim.pydev/vim/eclim/ftplugin/htmldjango.vim
+++ b/org.eclim.pydev/vim/eclim/ftplugin/htmldjango.vim
@@ -38,6 +38,7 @@ let g:HtmlDjangoBodyElements = [
     \ ['autoescape', 'endautoescape'],
     \ ['block', 'endblock'],
     \ ['blocktrans', 'plural', 'endblocktrans'],
+    \ ['cache', 'endcache'],
     \ ['comment', 'endcomment'],
     \ ['filter', 'endfilter'],
     \ ['for', 'empty', 'endfor'],


### PR DESCRIPTION
Currently only space is considered for the ending tags.
