### PR TITLE
Remove endwise config from eclim, use enhanced version from upstream

### DIFF
--- a/org.eclim.pydev/vim/eclim/ftplugin/htmldjango.vim
+++ b/org.eclim.pydev/vim/eclim/ftplugin/htmldjango.vim
@@ -91,10 +91,6 @@ endif
 
 " Options {{{
 
-let b:endwise_addition = '{% end& %}'
-let b:endwise_words = 'block,if,while,for'
-let b:endwise_syngroups = 'djangoStatement'
-
 " }}}
 
 " vim:ft=vim:fdm=marker


### PR DESCRIPTION
This should get merged when the endwise pull request is accepted:
https://github.com/tpope/vim-endwise/pull/64

I had a local setup for endwise+htmldjango and noticed that it eclim interfered here. I have submitted an enhanced and fixed version upstream. Eclim's version has less trigger words, and adds an end block every time.
