### PR TITLE
Use last winnr instead of bufnr for LocateFile

### DIFF
--- a/org.eclim.core/vim/eclim/autoload/eclim/common/locate.vim
+++ b/org.eclim.core/vim/eclim/autoload/eclim/common/locate.vim
@@ -214,6 +214,7 @@ endfunction " }}}
 function! s:LocateFileCompletionInit(action, scope, project, workspace) " {{{
   let file = expand('%')
   let bufnum = bufnr('%')
+  let winnr = winnr()
   let winrestcmd = winrestcmd()
 
   topleft 12split [Locate\ Results]
@@ -238,6 +239,7 @@ function! s:LocateFileCompletionInit(action, scope, project, workspace) " {{{
   setlocal buftype=nofile bufhidden=delete
 
   let b:bufnum = bufnum
+  let b:winnr = winnr
   let b:project = a:project
   let b:workspace = a:workspace
   let b:scope = a:scope
@@ -359,6 +361,7 @@ function! s:LocateFileSelect(action) " {{{
     endif
 
     let bufnum = b:bufnum
+    let winnr = b:winnr
     let winrestcmd = b:winrestcmd
 
     " close locate windows
@@ -369,7 +372,8 @@ function! s:LocateFileSelect(action) " {{{
     exec winrestcmd
 
     " open the selected result
-    call eclim#util#GoToBufferWindow(bufnum)
+    exec winnr . "wincmd w"
+    " call eclim#util#GoToBufferWindow(bufnum)
     call eclim#util#GoToBufferWindowOrOpen(file, a:action)
     call feedkeys("\<esc>", 'n')
     doautocmd WinEnter


### PR DESCRIPTION
Fixes issue where calling LocateFile from a split window with
`g:EclimLocateFileDefaultAction = 'edit'`
doesn't always open in the window you expect.

Repro:
- `:e A`
- `:vsp`; `<ctrl-w><ctrl-h>` (go to "left" window)
- `:e B`
- `:sp`; `<ctrl-w><ctrl-j>` (go to bottom-left window)
- `:LocateFile` etc.

Previously, when you select a file (with `<ctrl-e>`, or just using
the `DefaultAction` above) it would open in the top-left window,
even though you started in the bottom-left.

Please let me know if there are cases this breaks on
