### PR TITLE
Add EchoSuccess function; switch JUnit result line to use it

### DIFF
--- a/org.eclim.core/vim/eclim/autoload/eclim/util.vim
+++ b/org.eclim.core/vim/eclim/autoload/eclim/util.vim
@@ -157,8 +157,17 @@ endfunction " }}}
 
 function! eclim#util#Echo(message) " {{{
   " Echos a message using the info highlight regardless of what log level is set.
+  call s:EchoHighlight(a:message, g:EclimHighlightInfo)
+endfunction " }}}
+
+function! eclim#util#EchoSuccess(message) " {{{
+  " Echos a message using the 'success' highlight regardless log level
+    call s:EchoHighlight(a:message, g:EclimHighlightSuccess)
+endfunction " }}}
+
+function! s:EchoHighlight(message, highlight) " {{{
   if a:message != "0"
-    exec "echohl " . g:EclimHighlightInfo
+    exec "echohl " . a:highlight
     redraw
     for line in split(a:message, '\n')
       echom line

--- a/org.eclim.core/vim/eclim/plugin/eclim.vim
+++ b/org.eclim.core/vim/eclim/plugin/eclim.vim
@@ -57,6 +57,9 @@ call eclim#AddVimSetting(
 call eclim#AddVimSetting(
   \ 'Core', 'g:EclimHighlightError', 'Error',
   \ 'Sets the vim highlight group to be used for error messages/signs.')
+call eclim#AddVimSetting(
+  \ 'Core', 'g:EclimHighlightSuccess', 'MoreMsg',
+  \ 'Sets the vim highlight group to be used for success messages/signs.')
 
 call eclim#AddVimSetting(
   \ 'Core', 'g:EclimMenus', 1,

--- a/org.eclim.jdt/vim/eclim/autoload/eclim/java/junit.vim
+++ b/org.eclim.jdt/vim/eclim/autoload/eclim/java/junit.vim
@@ -79,7 +79,7 @@ function! eclim#java#junit#JUnit(test, bang) " {{{
       quit
       exec curwinnr . "winc w"
     endif
-    call eclim#util#Echo(statusLine[0])
+    call eclim#util#EchoSuccess(statusLine[0])
   elseif result != '0'
     " if result == '0', then there was some error;
     "  results won't have anything interesting anyway


### PR DESCRIPTION
So we can customize the highlight for successful JUnit calls, as suggested in #351
