### PR TITLE
Fixing issue with case sensitivity in Mac OSX

### DIFF
--- a/org.eclim.core/vim/eclim/autoload/eclim/project/util.vim
+++ b/org.eclim.core/vim/eclim/autoload/eclim/project/util.vim
@@ -901,7 +901,7 @@ function! eclim#project#util#GetProjectRelativeFilePath(...) " {{{
 
   let file = substitute(fnamemodify(file, ':p'), '\', '/', 'g')
   let pattern = '\(/\|$\)'
-  if has('win32') || has('win64')
+  if has('win32') || has('win64') || has('macunix')
     let pattern .= '\c'
   endif
   let result = substitute(file, get(project, 'path', '') . pattern, '', '')
@@ -989,7 +989,7 @@ function! eclim#project#util#GetProject(path) " {{{
 
   let path = substitute(fnamemodify(path, ':p'), '\', '/', 'g')
   let pattern = '\(/\|$\)'
-  if has('win32') || has('win64')
+  if has('win32') || has('win64') || has('macunix')
     let pattern .= '\c'
   endif
 


### PR DESCRIPTION
Discussion here:  https://groups.google.com/forum/#!topic/eclim-user/-JN0CaFzUsE

This is every place in eclim where there was a case sensitivity flag added to a regular expression that was guarded by a "has('win32') || has('win64')" if statement.  I made these changes in my eclim installation and it now successfully picks up the correct project.

This was forked off the 2.3.4 tag, which is the version that I am using.
