### PR TITLE
Externalize the text on sign column that shows current line being

### DIFF
--- a/doc/content/vim/java/debug.rst
+++ b/doc/content/vim/java/debug.rst
@@ -181,6 +181,10 @@ Configuration
 
   Highlight group to use for showing the current line being debugged.
 
+- **g:EclimJavaDebugLineSignText** (Default: '•')
+
+  Text to use on sign column for showing the current line being debugged.
+
 - **g:EclimJavaDebugStatusWinOrientation** (Default: 'vertical')
 
   Sets the orientation for the splits inside the debug status windows;

--- a/org.eclim.jdt/vim/eclim/autoload/eclim/java/debug.vim
+++ b/org.eclim.jdt/vim/eclim/autoload/eclim/java/debug.vim
@@ -613,7 +613,8 @@ function! eclim#java#debug#GoToFile(file, line) " {{{
   silent! call eclim#display#signs#Undefine(s:breakpoint_sign_current)
 
   call eclim#display#signs#Define(
-    \ s:breakpoint_sign_current, '•',
+    \ s:breakpoint_sign_current,
+    \ g:EclimJavaDebugLineSignText,
     \ g:EclimHighlightSuccess,
     \ g:EclimJavaDebugLineHighlight)
   call eclim#display#signs#PlaceInBuffer(

--- a/org.eclim.jdt/vim/eclim/plugin/settings_java.vim
+++ b/org.eclim.jdt/vim/eclim/plugin/settings_java.vim
@@ -106,6 +106,10 @@
     \ 'Highlight group to use for showing the current line being debugged.')
 
   call eclim#AddVimSetting(
+    \ 'Lang/Java', 'g:EclimJavaDebugLineSignText', '•',
+    \ 'Text to use on sign column for showing the current line being debugged.')
+
+  call eclim#AddVimSetting(
     \ 'Lang/Java', 'g:EclimJavaDebugStatusWinOrientation', 'vertical',
     \ 'Sets the orientation for the splits inside the debug status windows; ' .
     \ 'if they should be tiled vertically or horizontally.')


### PR DESCRIPTION
debugged.

I liked to use the '▸' symbol instead of period. So externalized this
as a setting for other users.
