### PR TITLE
Display test code references after all the main code references.

### DIFF
--- a/org.eclim.core/vim/eclim/autoload/eclim/project/util.vim
+++ b/org.eclim.core/vim/eclim/autoload/eclim/project/util.vim
@@ -173,6 +173,22 @@ function! s:ProjectNatureHooks(natureIds, hookName, args) " {{{
   return 1
 endfunction " }}}
 
+function! eclim#project#util#ProjectImportDiscover(arg) " {{{
+  " Recursively searches the given directory for any project files
+  " and imports them.
+  let projects = split(globpath(a:arg, '**/.project'), '\n')
+  if (len(projects) == 0)
+    call eclim#util#Echo("No projects found")
+    return
+  endif
+
+  for project in projects
+    call eclim#project#util#ProjectImport(fnamemodify(project, ':h'))
+  endfor
+
+  call eclim#util#Echo("Imported " . len(projects) . " projects.")
+endfunction " }}}
+
 function! eclim#project#util#ProjectImport(arg) " {{{
   let folder = fnamemodify(expand(a:arg), ':p')
   let folder = substitute(folder, '\', '/', 'g')

--- a/org.eclim.core/vim/eclim/plugin/project.vim
+++ b/org.eclim.core/vim/eclim/plugin/project.vim
@@ -123,6 +123,8 @@ if !exists(":ProjectCreate")
     \ -complete=customlist,eclim#project#util#CommandCompleteProjectCreate
     \ ProjectCreate :call eclim#project#util#ProjectCreate('<args>')
   command -nargs=1 -complete=dir
+    \ ProjectImportDiscover :call eclim#project#util#ProjectImportDiscover('<args>')
+  command -nargs=1 -complete=dir
     \ ProjectImport :call eclim#project#util#ProjectImport('<args>')
   command -nargs=1
     \ -complete=customlist,eclim#project#util#CommandCompleteProject


### PR DESCRIPTION
It is useful to group main and test code instead of interleaving them.
Typically, we do code reference to identify the main code flow and so
we don't care about test code references.

We need a better way to group references based on package, but that requires
VIM side changes. So for now this will address the need.

Testing:
Verified the test references are listed in the end.
