### PR TITLE
JavaSearchContext command should look for references.

### DIFF
--- a/org.eclim.jdt/java/org/eclim/plugin/jdt/command/search/SearchCommand.java
+++ b/org.eclim.jdt/java/org/eclim/plugin/jdt/command/search/SearchCommand.java
@@ -545,7 +545,7 @@ public class SearchCommand
         theClass.equals(org.eclipse.jdt.internal.core.SourceField.class) ||
         theClass.equals(org.eclipse.jdt.internal.core.SourceMethod.class))
     {
-      return IJavaSearchConstants.ALL_OCCURRENCES;
+      return IJavaSearchConstants.REFERENCES;
     }
 
     return IJavaSearchConstants.DECLARATIONS;


### PR DESCRIPTION
As per the documentation, only references should be returned when the
cursor is on method/field declaration. Also, this makes sense from
usability perspective as we don't need to include the current line in
the results.

Testing:
Verified that current line is not included in result set and only
references are returned when cursor in on a public method.
