### PR TITLE
Open quickfix window using botright option.

### DIFF
--- a/org.eclim.core/vim/eclim/autoload/eclim/lang.vim
+++ b/org.eclim.core/vim/eclim/autoload/eclim/lang.vim
@@ -218,7 +218,8 @@ function! eclim#lang#SearchResults(results, action) " {{{
 
       let &autochdir = save_autochdir
     endif
-    exec 'copen ' . g:EclimQuickfixHeight
+    " Using botright to handle multiple splits windows. See :h window
+    exec 'botright copen ' . g:EclimQuickfixHeight
   endif
 endfunction " }}}
 


### PR DESCRIPTION
Otherwise, when there are multiple splits, quickfix window is opened as
a split of the rightmost window.

Testing:
Created a vertical split of window and then opened quickfix window.
The window is opened at the bottom spanning both windows.
