### PR TITLE
Ignore substitution error in debug status window.

### DIFF
--- a/org.eclim.jdt/vim/eclim/autoload/eclim/java/debug.vim
+++ b/org.eclim.jdt/vim/eclim/autoload/eclim/java/debug.vim
@@ -755,7 +755,7 @@ function! eclim#java#debug#SessionTerminated() " {{{
 
   " Go to line having the thread id
   call cursor(1, 1)
-  s/Connect\(ed\|ing\)/Disconnected/
+  s/Connect\(ed\|ing\)/Disconnected/e
 
   " Delete any threads that have not been cleared
   if line('$') > 1


### PR DESCRIPTION
This case can happen when there are no breakpoints and we start a debugging
session.
