### PR TITLE
Fixed documentation to reflect more robust code

### DIFF
--- a/doc/content/vim/code_completion.rst
+++ b/doc/content/vim/code_completion.rst
@@ -88,7 +88,7 @@ usage less cumbersome:
 
     let g:acp_behaviorJavaEclimLength = 3
     function MeetsForJavaEclim(context)
-      return g:acp_behaviorJavaEclimLength >= 0 &&
+      return g:acp_behaviorJavaEclimLength >= 0 && exists(":Java") &&
             \ a:context =~ '\k\.\k\{' . g:acp_behaviorJavaEclimLength . ',}$'
     endfunction
     let g:acp_behavior = {


### PR DESCRIPTION
As describes here:
https://bitbucket.org/ns9tks/vim-autocomplpop/issue/51/a-z-a-z-auto-completes-to-acp-onpopuppost

It's common for problems to occur, one of the main causes was that java files outside of eclim projects were throwing exceptions and causing the issue. I added a check to ensure this doesn't happen.

=acp#onPopupPost()