### PR TITLE
Fix issues with sphinx 1.3

### DIFF
--- a/doc/extension/eclim/sphinx/rss.py
+++ b/doc/extension/eclim/sphinx/rss.py
@@ -8,7 +8,6 @@ from docutils.parsers.rst import Directive, directives, Parser
 from sphinx.builders.html import StandaloneHTMLBuilder
 from sphinx.writers.html import HTMLTranslator, HTMLWriter
 from sphinx.util.osutil import os_path
-from sphinx.util.pycompat import b
 
 class RssTranslator(HTMLTranslator):
     def __init__(self, *args, **kwargs):
@@ -105,10 +104,13 @@ class RssInsertDirective(Directive):
         source = self.state_machine.input_lines.source(
             self.lineno - self.state_machine.input_offset - 1)
 
-        rss_doc = utils.new_document(b('<rss>'), self.state.document.settings)
+        rss_doc = utils.new_document(b'<rss>', self.state.document.settings)
         Parser().parse('\n'.join(self.content), rss_doc)
 
-        rst_suffix = env.config.source_suffix
+        if isinstance(env.config.source_suffix, (list, tuple)):
+            rst_suffix = env.config.source_suffix[0]
+        else:
+            rst_suffix = env.config.source_suffix
         path = os.path.relpath(source, env.srcdir).replace(rst_suffix, '.html')
 
         builder = env.app.builder
@@ -142,7 +144,7 @@ class RssInsertDirective(Directive):
                 node = nodes.paragraph()
                 node.extend(child.children[title_index + 1:])
 
-                sec_doc = utils.new_document(b('<rss-section>'), docsettings)
+                sec_doc = utils.new_document(b'<rss-section>', docsettings)
                 sec_doc.append(node)
                 visitor = RssTranslator(builder, sec_doc)
                 sec_doc.walkabout(visitor)


### PR DESCRIPTION
Currently, the docs don't build with sphinx 1.3. This pull request should fix that.

This must be merged with ervandew/sphinx-bootstrap-theme#1 as well, and the submodule updated.