### PR TITLE
Add missing parameter to createTextFileChange()

### DIFF
--- a/org.eclim.sdt/scala/eclim/plugin/sdt/command/include/ImportCommand.scala
+++ b/org.eclim.sdt/scala/eclim/plugin/sdt/command/include/ImportCommand.scala
@@ -132,7 +132,7 @@ class ImportCommand
       val project = src.getJavaProject.getProject
       val document = ProjectUtils.getDocument(project, file)
       val ifile = ProjectUtils.getFile(project, file)
-      val edit = TextEditUtils.createTextFileChange(ifile, changes).getEdit
+      val edit = TextEditUtils.createTextFileChange(ifile, changes, leaveDirty = false).getEdit
       JavaModelUtil.applyEdit(src, edit, true, null)
 
       exception match {


### PR DESCRIPTION
Building with the latest ScalaIDE, I get the following trace:
```
------ org.eclim.jdt.build.eclipse
     [echo] 
     [echo] building plugin: org.eclim.sdt
    [mkdir] Created dir: /home/euclio/build/eclim-git/src/eclim-git/build/temp/eclipse/plugins/org.eclim.sdt_2.4.1.8-gcc3816e
org.eclim.sdt.plugin.compile:
    [mkdir] Created dir: /home/euclio/build/eclim-git/src/eclim-git/build/temp/classes/org.eclim.sdt
   [scalac] Compiling 7 source files to /home/euclio/build/eclim-git/src/eclim-git/build/temp/classes/org.eclim.sdt
   [scalac] /home/euclio/build/eclim-git/src/eclim-git/org.eclim.sdt/scala/eclim/plugin/sdt/command/include/ImportCommand.scala:135: error: not enough arguments for method createTextFileChange: (file: org.eclipse.core.resources.IFile, fileChanges: List[scala.tools.refactoring.common.TextChange], leaveDirty: Boolean)org.eclipse.ltk.core.refactoring.TextFileChange.
   [scalac] Unspecified value parameter leaveDirty.
   [scalac]       val edit = TextEditUtils.createTextFileChange(ifile, changes).getEdit
   [scalac]                                                    ^
   [scalac] one error found
```

Fixed by adding the parameter added by [this commit](https://github.com/scala-ide/scala-ide/commit/6345894dc8ad95571d794f819813a0abec85c5aa).