### PR TITLE
Make it possible to override home dir in vimrc

### DIFF
--- a/org.eclim.core/vim/eclim/autoload/eclim.vim
+++ b/org.eclim.core/vim/eclim/autoload/eclim.vim
@@ -556,7 +556,9 @@ function! eclim#SaveVimSettings() " {{{
 endfunction " }}}
 
 function! eclim#UserHome() " {{{
-  if has('win32unix')
+  if exists('g:EclimUserHome')
+    let home = g:EclimUserHome
+  elseif has('win32unix')
     let home = eclim#cygwin#WindowsHome()
   elseif has('win32') || has('win64')
     let home = expand('$USERPROFILE')


### PR DESCRIPTION
I needed this so I could point eclim at my actual home directory, not the parent directory of the output of cygpath -D