### PR TITLE
Fix a broken link

### DIFF
--- a/org.eclim.installer/build/resources/templates/welcome.html
+++ b/org.eclim.installer/build/resources/templates/welcome.html
@@ -5,12 +5,12 @@
     Before proceeding, please ensure that your system meets the following
     requirements:
     <p>
-    &nbsp;&nbsp;&nbsp;&nbsp;- <a href="http://www.oracle.com/technetwork/java/javase/downloads/index.html">Jdk 1.6</a> (or greater)<br>
+    &nbsp;&nbsp;&nbsp;&nbsp;- <a href="http://www.oracle.com/technetwork/java/javase/downloads/index.html">JDK 1.6</a> (or greater)<br>
     &nbsp;&nbsp;&nbsp;&nbsp;- <a href="http://eclipse.org/downloads">Eclipse 4.5.x (Mars)</a><br>
     &nbsp;&nbsp;&nbsp;&nbsp;- <a href="http://www.vim.org/download.php">Vim 7</a>
     <p>
     For more information on installing eclim, please visit the
-    <a href="http://eclim.org/guides/install.html">installation guide</a>
+    <a href="http://eclim.org/install.html">installation guide</a>
     online.
   </body>
 </html>


### PR DESCRIPTION
The link to the installation guide in `org.eclim.installer/build/resources/templates/welcome.html` is 404.