### PR TITLE
bin/dependencies bug fix

### DIFF
--- a/bin/dependencies
+++ b/bin/dependencies
@@ -65,12 +65,18 @@ def getEclimHome():
   return os.path.dirname(sys.path[0])
 
 def getEclipseHome(eclimHome):
+  properties_path = eclimHome + '/user.properties'
+  if not os.path.isfile(properties_path):
+    if 'ECLIM_ECLIPSE_HOME' in os.environ:
+      return os.environ['ECLIM_ECLIPSE_HOME']
+    raise Exception('ECLIM_ECLIPSE_HOME environment variable not set.')
+
   branch = Popen(
     'git rev-parse --abbrev-ref HEAD',
     cwd=eclimHome, shell=True, stdout=PIPE
   ).stdout.read().strip()
   props = {}
-  for line in open(eclimHome + '/user.properties').read().split('\n'):
+  for line in open(propertiesPath).read().split('\n'):
     if not line or line.strip().startswith('#'):
       continue
     key, _, value = line.strip().partition('=')


### PR DESCRIPTION
- ECLIM_ECLIPSE_HOME environment variable is used to set eclimHome
if user.properties file is not found.