### PR TITLE
GroovyCompleteJavaDocURI

### DIFF
--- a/org.eclim.core/java/org/eclim/plugin/core/command/complete/CodeCompleteResult.java
+++ b/org.eclim.core/java/org/eclim/plugin/core/command/complete/CodeCompleteResult.java
@@ -51,6 +51,7 @@ public class CodeCompleteResult
   private String type;
   private Integer offset = null;
   private int relevance;
+  private String javaDocURI = "";
 
   /**
    * Constructs a new instance.
@@ -90,11 +91,28 @@ public class CodeCompleteResult
   public CodeCompleteResult (
       String completion, String menu, String info, String type, Integer offset)
   {
+    this(completion, menu, info, type, offset, StringUtils.EMPTY);
+  }
+
+  /**
+   * Constructs a new instance.
+   *
+   * @param completion The completion string.
+   * @param menu The menu text of the completion.
+   * @param info The completion info details.
+   * @param type The completion type.
+   * @param offset Starting offset at which the completion should be inserted
+   * @param javaDocURI The java doc URI link of the completion.
+   */
+  public CodeCompleteResult(String completion, String menu, String info,
+      String type, Integer offset, String javaDocURI)
+  {
     this.completion = completion;
     this.menu = menu;
     this.info = info;
     this.type = type != null ? type : StringUtils.EMPTY;
     this.offset = offset;
+    this.setJavaDocURI(javaDocURI);
 
     if(this.info != null){
       this.info = StringUtils.replace(this.info, "\n", "<br/>");
@@ -189,6 +207,22 @@ public class CodeCompleteResult
   public void setOffset(int offset)
   {
     this.offset = offset;
+  }
+
+  /**
+   * @return The javaDocURI
+   */
+  public String getJavaDocURI()
+  {
+    return javaDocURI;
+  }
+
+  /**
+   * @param javaDocURI The javaDocURI to set
+   */
+  public void setJavaDocURI(String javaDocURI)
+  {
+    this.javaDocURI = javaDocURI;
   }
 
   /**

--- a/org.eclim.groovy/java/org/eclim/plugin/groovy/command/complete/CodeCompleteCommand.java
+++ b/org.eclim.groovy/java/org/eclim/plugin/groovy/command/complete/CodeCompleteCommand.java
@@ -29,7 +29,7 @@ import org.codehaus.jdt.groovy.model.GroovyCompilationUnit;
 import org.eclim.annotation.Command;
 
 import org.eclim.command.CommandLine;
-
+import org.eclim.command.Options;
 import org.eclim.plugin.core.command.complete.CodeCompleteResult;
 
 import org.eclim.plugin.core.util.ProjectUtils;
@@ -53,6 +53,14 @@ import org.eclipse.ui.ide.IDE;
 
 /**
  * Command which provides code completion for groovy files.
+ *
+ * @param javaDoc
+ *    The {@code javaDoc} parameter specifies if a javaDoc URI should be returned
+ *    for each of the completion proposals.
+ *    If {@code javaDoc} = true for each completion a eclipse style java doc URI
+ *    will be returned which can be converted to java doc over the
+ *    {@code java_element_doc} command.
+ *    If {@code javaDoc} = false no javadoc URI will be returned
  */
 @Command(
   name = "groovy_complete",
@@ -61,7 +69,8 @@ import org.eclipse.ui.ide.IDE;
     "REQUIRED f file ARG," +
     "REQUIRED o offset ARG," +
     "REQUIRED e encoding ARG," +
-    "REQUIRED l layout ARG"
+    "REQUIRED l layout ARG," +
+    "OPTIONAL j javaDoc ARG"
 )
 public final class CodeCompleteCommand
   extends org.eclim.plugin.jdt.command.complete.CodeCompleteCommand
@@ -104,9 +113,12 @@ public final class CodeCompleteCommand
       proposals = Collections.emptyList();
     }
 
+    boolean javaDocEnabled = Boolean
+        .parseBoolean(commandLine.getValue(Options.JAVA_DOC_OPTION));
     ArrayList<CodeCompleteResult> results = new ArrayList<CodeCompleteResult>();
     for(ICompletionProposal proposal : proposals){
-      results.add(createCompletionResult((IJavaCompletionProposal)proposal));
+      results.add(createCompletionResult((IJavaCompletionProposal) proposal,
+          javaDocEnabled));
     }
     Collections.sort(results, COMPLETION_COMPARATOR);
 

--- a/org.eclim.groovy/java/org/eclim/plugin/groovy/command/complete/CodeCompleteCommand.java
+++ b/org.eclim.groovy/java/org/eclim/plugin/groovy/command/complete/CodeCompleteCommand.java
@@ -70,7 +70,7 @@ import org.eclipse.ui.ide.IDE;
     "REQUIRED o offset ARG," +
     "REQUIRED e encoding ARG," +
     "REQUIRED l layout ARG," +
-    "OPTIONAL j javaDoc ARG"
+    "OPTIONAL j javaDoc ARG NOARG"
 )
 public final class CodeCompleteCommand
   extends org.eclim.plugin.jdt.command.complete.CodeCompleteCommand
@@ -113,8 +113,7 @@ public final class CodeCompleteCommand
       proposals = Collections.emptyList();
     }
 
-    boolean javaDocEnabled = Boolean
-        .parseBoolean(commandLine.getValue(Options.JAVA_DOC_OPTION));
+    boolean javaDocEnabled = commandLine.hasOption(Options.JAVA_DOC_OPTION);
     ArrayList<CodeCompleteResult> results = new ArrayList<CodeCompleteResult>();
     for(ICompletionProposal proposal : proposals){
       results.add(createCompletionResult((IJavaCompletionProposal) proposal,

--- a/org.eclim.groovy/test/eclim_unit_test_groovy/src/org/eclim/test/complete/TestCompletionJavaDoc.groovy
+++ b/org.eclim.groovy/test/eclim_unit_test_groovy/src/org/eclim/test/complete/TestCompletionJavaDoc.groovy
@@ -1,0 +1,9 @@
+package org.eclim.test.complete
+
+public class TestCompletion {
+
+  def test(){
+    Integer i;
+    i. 
+  }
+}

--- a/org.eclim.groovy/test/junit/org/eclim/plugin/groovy/command/complete/CodeCompleteCommandTest.java
+++ b/org.eclim.groovy/test/junit/org/eclim/plugin/groovy/command/complete/CodeCompleteCommandTest.java
@@ -28,8 +28,6 @@ import org.eclim.plugin.groovy.Groovy;
 
 import org.junit.Test;
 
-import junit.framework.Assert;
-
 /**
  * Test case for CodeCompleteCommand.
  *
@@ -63,45 +61,42 @@ public class CodeCompleteCommandTest
     result = results.get(1);
     assertEquals(result.get("completion"), "addAll(");
   }
-  
+
   @Test
   public void javaDoc(){
     assertTrue("Groovy project doesn't exist.",
         Eclim.projectExists(Groovy.TEST_PROJECT));
-    int count = getJavaDocCount("true");
+    int count = getJavaDocCount("anything");
+    assertJavaDocPresent(count);
+  }
+
+  @Test
+  public void JavaDocEmpty(){
+    assertTrue("Groovy project doesn't exist.",
+        Eclim.projectExists(Groovy.TEST_PROJECT));
+    int count = getJavaDocCount("");
+    assertJavaDocPresent(count);
+  }
+
+  private void assertJavaDocPresent(int count)
+  {
     // We do not compare with the actual number to make
     // the test more robust ==> if something in eclipse
     // changes and some elements do not exist anymore /
     // do not have a javaDoc element the test still
     // succeeds.
     int minimalCount = 50;
-    Assert.assertTrue("We received some JavaDoc links", count > minimalCount);
+    assertTrue("We should receive some JavaDoc links", count > minimalCount);
   }
-  
+
   @Test
-  public void noJavaDocFalse(){
-    assertTrue("Groovy project doesn't exist.",
-        Eclim.projectExists(Groovy.TEST_PROJECT));
-    int count = getJavaDocCount("false");
-    Assert.assertEquals("We should receive no JavaDoc links, since the java doc flag is set to false", 0, count);
-  }
-  
-  @Test
-  public void noJavaDocEmpty(){
-    assertTrue("Groovy project doesn't exist.",
-        Eclim.projectExists(Groovy.TEST_PROJECT));
-    int count = getJavaDocCount("");
-    Assert.assertEquals("We should receive no JavaDoc links, since the java doc flag is set to empty string", 0, count);
-  }
-  
-  @Test
-  public void noJavaDocDefault(){
+  public void noJavaDoc(){
     assertTrue("Groovy project doesn't exist.",
         Eclim.projectExists(Groovy.TEST_PROJECT));
     int count = getJavaDocCountNoJavaDocFlag();
-    Assert.assertEquals("We should receive no JavaDoc links, since the java doc flag is not set", 0, count);
+    assertEquals("We should receive no JavaDoc links, since the java doc flag is not set", 0, count);
   }
-  
+
   @SuppressWarnings("unchecked")
   private int getJavaDocCount(String javaDocArg){
     assertTrue("Groovy project doesn't exist.",
@@ -110,7 +105,6 @@ public class CodeCompleteCommandTest
     List<Map<String, String>> results = (List<Map<String, String>>) Eclim
         .execute(new String[] { "groovy_complete", "-p", Groovy.TEST_PROJECT, "-f",
             TEST_JAVA_DOC_FILE, "-l", "compact", "-o", "99", "-e", "utf-8", "-j", javaDocArg });
-    
 
     return countJavaDocOccurence(results);
   }
@@ -123,11 +117,10 @@ public class CodeCompleteCommandTest
     List<Map<String, String>> results = (List<Map<String, String>>) Eclim
         .execute(new String[] { "groovy_complete", "-p", Groovy.TEST_PROJECT, "-f",
             TEST_JAVA_DOC_FILE, "-l", "compact", "-o", "99", "-e", "utf-8",});
-    
+
     return countJavaDocOccurence(results);
   }
-  
-  
+
   private int countJavaDocOccurence(List<Map<String, String>> results)
   {
     int count = 0;

--- a/org.eclim/java/org/eclim/command/Options.java
+++ b/org.eclim/java/org/eclim/command/Options.java
@@ -68,6 +68,7 @@ public class Options
   public static final String INDENT_OPTION = "i";
   public static final String INDEXED_OPTION = "i";
   public static final String JARS_OPTION = "j";
+  public static final String JAVA_DOC_OPTION = "j";
   public static final String LANG_OPTION = "l";
   public static final String LAUNCH_ID_OPTION = "l";
   public static final String LAYOUT_OPTION = "l";


### PR DESCRIPTION
We changed the '**groovy_complete**' command:
The client can now request java doc links for each of the suggestions.

**How:**
We added a new flag 'javaDoc' to the 'groovy_complete' command. If this flag is set to 'true', the URI link which points to the java doc of the corresponding suggestion is returned in an additional field 'javaDocURI' in each CodeCompleteResult. If no URI can be created, the 'javaDocURI' field is set to an empty string.
If the flag is set to 'false', the 'javaDocURI' is set to an empty string.


**Use case:**
We want to present java doc for each of the completions if the user selects the completion. We can request the java doc over the java doc URI which we can now get along with the completions with the extended 'groovy_complete' command.

Note: We needed java reflections to get to the java doc URI, which is not very nice, but there was no other way to get the URI. In the eclim plugin reflection is already used a lot and we do not want to change eclipse so we think this is the best solution.