### PR TITLE
Added HTML option to GetElementDocCommand

### DIFF
--- a/org.eclim.jdt/java/org/eclim/plugin/jdt/command/doc/GetElementDocCommand.java
+++ b/org.eclim.jdt/java/org/eclim/plugin/jdt/command/doc/GetElementDocCommand.java
@@ -65,7 +65,8 @@ import org.eclipse.jface.text.IRegion;
     "OPTIONAL o offset ARG," +
     "OPTIONAL l length ARG," +
     "OPTIONAL e encoding ARG," +
-    "OPTIONAL u url ARG"
+    "OPTIONAL u url ARG," +
+    "OPTIONAL h htmlFlag ARG"
 )
 public class GetElementDocCommand
   extends AbstractCommand
@@ -112,6 +113,10 @@ public class GetElementDocCommand
       return null;
     }
 
+    if(returnHTML(commandLine)){
+      return info.getHtml();
+    }
+
     ArrayList<HashMap<String,String>> links =
       new ArrayList<HashMap<String,String>>();
     Matcher matcher = LINKS.matcher(info.getHtml());
@@ -140,5 +145,11 @@ public class GetElementDocCommand
     response.put("text", result);
     response.put("links", links);
     return response;
+  }
+
+  private boolean returnHTML(CommandLine commandLine)
+      throws Exception
+  {
+    return Boolean.parseBoolean(commandLine.getValue(Options.HTML_OPTION));
   }
 }

--- a/org.eclim.jdt/java/org/eclim/plugin/jdt/command/doc/GetElementDocCommand.java
+++ b/org.eclim.jdt/java/org/eclim/plugin/jdt/command/doc/GetElementDocCommand.java
@@ -66,7 +66,7 @@ import org.eclipse.jface.text.IRegion;
     "OPTIONAL l length ARG," +
     "OPTIONAL e encoding ARG," +
     "OPTIONAL u url ARG," +
-    "OPTIONAL h htmlFlag ARG"
+    "OPTIONAL h html NOARG"
 )
 public class GetElementDocCommand
   extends AbstractCommand
@@ -113,7 +113,7 @@ public class GetElementDocCommand
       return null;
     }
 
-    if(returnHTML(commandLine)){
+    if(commandLine.hasOption(Options.HTML_OPTION)){
       return info.getHtml();
     }
 
@@ -145,11 +145,5 @@ public class GetElementDocCommand
     response.put("text", result);
     response.put("links", links);
     return response;
-  }
-
-  private boolean returnHTML(CommandLine commandLine)
-      throws Exception
-  {
-    return Boolean.parseBoolean(commandLine.getValue(Options.HTML_OPTION));
   }
 }

--- a/org.eclim.jdt/test/junit/org/eclim/plugin/jdt/command/doc/GetElementDocCommandTest.java
+++ b/org.eclim.jdt/test/junit/org/eclim/plugin/jdt/command/doc/GetElementDocCommandTest.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import org.eclim.Eclim;
 
 import org.eclim.plugin.jdt.Jdt;
-import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -177,6 +176,6 @@ public class GetElementDocCommandTest
         "java_element_doc", "-p", Jdt.TEST_PROJECT,
         "-f", TEST_FILE, "-o", "255", "-l", "11", "-e", "utf-8", "-h", "true"
       });
-    Assert.assertTrue("HTML Format expected", results.startsWith("<html><head>"));
+    assertTrue("HTML Format expected", results.startsWith("<html><head>"));
   }
 }

--- a/org.eclim.jdt/test/junit/org/eclim/plugin/jdt/command/doc/GetElementDocCommandTest.java
+++ b/org.eclim.jdt/test/junit/org/eclim/plugin/jdt/command/doc/GetElementDocCommandTest.java
@@ -16,16 +16,17 @@
  */
 package org.eclim.plugin.jdt.command.doc;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.util.List;
 import java.util.Map;
 
 import org.eclim.Eclim;
 
 import org.eclim.plugin.jdt.Jdt;
-
+import org.junit.Assert;
 import org.junit.Test;
-
-import static org.junit.Assert.*;
 
 /**
  * Test case for GetElementDocCommand.
@@ -167,5 +168,15 @@ public class GetElementDocCommandTest
     assertTrue(text.startsWith(
         "|Object[0]| |java[1]|.|util[2]|.|Map[3]|.put(|Object[4]| key, |Object[5]| value)\n\n" +
         "Associates the specified value with the specified key in this map"));
+  }
+
+  @Test
+  public void htmlFlag(){
+    String results = (String)
+      Eclim.execute(new String[]{
+        "java_element_doc", "-p", Jdt.TEST_PROJECT,
+        "-f", TEST_FILE, "-o", "255", "-l", "11", "-e", "utf-8", "-h", "true"
+      });
+    Assert.assertTrue("HTML Format expected", results.startsWith("<html><head>"));
   }
 }

--- a/org.eclim/java/org/eclim/command/Options.java
+++ b/org.eclim/java/org/eclim/command/Options.java
@@ -65,6 +65,7 @@ public class Options
   public static final String HELP = "help";
   public static final String HALT_OPTION = "h";
   public static final String HOST_OPTION = "h";
+  public static final String HTML_OPTION = "h";
   public static final String INDENT_OPTION = "i";
   public static final String INDEXED_OPTION = "i";
   public static final String JARS_OPTION = "j";


### PR DESCRIPTION
# GetElementDocCommand ('java_element_doc')

We would like to **get the html result** (returned by eclipse) directly **without the modifications which are done for vim**.

We added an optioal HTML option to the GetElementDocCommand ('java_element_doc') command. If the optional 'htmlFlag' is set the returned java doc will be in a HTML format as eclipse uses it.