### PR TITLE
export ECLIM_ECLIPSE_HOME

### DIFF
--- a/doc/content/install.rst
+++ b/doc/content/install.rst
@@ -373,11 +373,21 @@ section for additional details):
 
 The last step is to start Xvfb followed by eclimd:
 
+.. note::
+  
+  Use this export to set an absolute path to Eclipse home for eclimd
+  
+  ::
+  
+.. code-block:: bash
+
+  $ export ECLIM_ECLIPSE_HOME=/usr/local/lib/eclipse # Works with official FreeBSD eclipse package
+
 ::
 
   $ Xvfb :1 -screen 0 1024x768x24 &
   $ DISPLAY=:1 ./eclipse/eclimd -b
-
+  
 When starting Xvfb you may receive some errors regarding font paths and
 possibly dbus and hal, but as long as Xvfb continues to run, you should be
 able to ignore these errors.


### PR DESCRIPTION
To inform others with non-relative ECLIM_ECLIPSE_HOME that you can export ECLIM_ECLIPSE_HOME on platforms such as FreeBSD where eclimd command fails due to non-relative ECLIM_ECLIPSE_HOME (/usr/local/lib/eclipse). It works out-of-the box if the variable is exported.