### PR TITLE
Autocomplete relevance field set for java+groovy code completions

### DIFF
--- a/org.eclim.core/java/org/eclim/plugin/core/command/complete/AbstractCodeCompleteCommand.java
+++ b/org.eclim.core/java/org/eclim/plugin/core/command/complete/AbstractCodeCompleteCommand.java
@@ -277,10 +277,12 @@ public abstract class AbstractCodeCompleteCommand
       info.append(o.getMenu());
     }
 
-    return new CodeCompleteResult(
+    CodeCompleteResult res = new CodeCompleteResult(
         r.getCompletion(),
         "Overloaded, see preview...",
         info.toString(),
         r.getType());
+    res.setRelevance(r.getRelevance());
+    return res;
   }
 }

--- a/org.eclim.jdt/java/org/eclim/plugin/jdt/command/complete/CodeCompleteCommand.java
+++ b/org.eclim.jdt/java/org/eclim/plugin/jdt/command/complete/CodeCompleteCommand.java
@@ -185,6 +185,9 @@ public class CodeCompleteCommand
     // of whether the user ever views it.
     /*return new CodeCompleteResult(
         kind, completion, menu, proposal.getAdditionalProposalInfo());*/
-    return new CodeCompleteResult(completion, menu, menu, type, offset);
+    CodeCompleteResult result = new CodeCompleteResult(completion, menu, menu, type,
+        offset);
+    result.setRelevance(proposal.getRelevance());
+    return result;
   }
 }


### PR DESCRIPTION
**Why we need this pull request:**
We want to be able to sort the suggestion in our own eclim client. There is already a pull request (#474) which would allow us to do so. For our use case it is enough to have the relevance field set, such that our client then can sort the suggestions. 

I wrote to @ocozalp and he told me he will not have time to go on with #474 right now -> #474  does not make process in the near time -> after a discussion with @ocozalp we both think that I should first add this change and then he will be able do his changes on top of this pull request.  My changes are a subset (with the additional fix of that the relevance field is not passed along in compact mode) of the pull request #474. The difference to #474 is that this request does not change the original behavior of eclim since nothing gets sorted. (One open question in #474).


**Content:**
- To enable the eclim client to sort the proposals according to their relevance the relevance field is set.
- The relevance field is not passed along when using compact mode -> fixed.


**NOTE:** Even if #474  would be accepted it would in my eyes make sense to add the changes of this request made in org.eclim.core/java/org/eclim/plugin/core/command/complete/AbstractCodeCompleteCommand.javaj

