### PR TITLE
Fix bug where eclim#lang#Refactor would not always restore cwd.

### DIFF
--- a/org.eclim.core/vim/eclim/autoload/eclim/lang.vim
+++ b/org.eclim.core/vim/eclim/autoload/eclim/lang.vim
@@ -465,11 +465,12 @@ function! eclim#lang#Refactor(command)
       endfor
     finally
       exec curwin . 'winc w'
-      if cwd_return
-        exec 'cd ' . escape(cwd, ' ')
-      endif
     endtry
   finally
+    if cwd_return
+      exec 'cd ' . escape(cwd, ' ')
+    endif
+
     " re-enable swap files
     let bufnum = 1
     while bufnum <= bufend


### PR DESCRIPTION
In some cases when a refactor fails, vim's cwd would not be properly restored and would be changed to the current project's directory.