### PR TITLE
Documentation fix: Add JavaNew to the cheatsheet

### DIFF
--- a/_sources/cheatsheet.txt
+++ b/_sources/cheatsheet.txt
@@ -222,6 +222,7 @@ Java Commands
 - :ref:`:Jps <:Jps>` -
   Opens window with information about the currently running java processes.
 - :ref:`:Validate <:Validate_java>` - Manually runs source code validation.
+- :ref:`:JavaNew <:JavaNew>`- Creates a new class, interface, enum, or annotation.
 
 
 Java .classpath Commands


### PR DESCRIPTION
`:JavaNew` is missing from the cheatsheet page, seems like it should be on there