### PR TITLE
Fixes issue #528: JavaDebugStatus fails

### DIFF
--- a/org.eclim.jdt/java/org/eclim/plugin/jdt/command/debug/ui/VariableView.java
+++ b/org.eclim.jdt/java/org/eclim/plugin/jdt/command/debug/ui/VariableView.java
@@ -221,14 +221,20 @@ public class VariableView
     }
 
     for (IVariable var : vars) {
-      JDIVariable jvar = (JDIVariable) var;
-      if (jvar.isSynthetic() ||
-          ignoreVar(jvar))
-      {
-        continue;
+      if (var instanceof JDIVariable) {
+        JDIVariable jdivar = (JDIVariable) var;
+        if (jdivar.isSynthetic() ||
+            ignoreVar(jdivar))
+        {
+          continue;
+        }
+      }
+      if (!(var instanceof IJavaVariable)) {
+	  continue;
       }
 
-      JDIValue value = (JDIValue) var.getValue();
+      IJavaVariable jvar = (IJavaVariable) var;
+      IJavaValue value = (IJavaValue)var.getValue();
       boolean isLeafNode = !((value != null) &&
         (value instanceof IJavaObject) &&
         value.hasVariables());


### PR DESCRIPTION
This fixes the class cast exception on cast 
from  DIReturnValueVariable (which is IJavaVariable but not JDIVariable)
 to JDIVariable.   