### PR TITLE
Fix StubUtility compile errors #601

### DIFF
--- a/org.eclim.jdt/java/org/eclim/plugin/jdt/command/impl/ConstructorCommand.java
+++ b/org.eclim.jdt/java/org/eclim/plugin/jdt/command/impl/ConstructorCommand.java
@@ -48,7 +48,7 @@ import org.eclipse.jdt.core.formatter.CodeFormatter;
 
 import org.eclipse.jdt.internal.corext.codemanipulation.AddCustomConstructorOperation;
 import org.eclipse.jdt.internal.corext.codemanipulation.CodeGenerationSettings;
-import org.eclipse.jdt.internal.corext.codemanipulation.StubUtility2;
+import org.eclipse.jdt.internal.corext.codemanipulation.StubUtility2Core;
 
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.Bindings;
@@ -194,7 +194,7 @@ public class ConstructorCommand
       constructor = Bindings.findMethodInType(
           binding, "Object", new ITypeBinding[0]);
     } else {
-      IMethodBinding[] bindings = StubUtility2
+      IMethodBinding[] bindings = StubUtility2Core
         .getVisibleConstructors(typeBinding, false, true);
       Arrays.sort(bindings, new Comparator<IMethodBinding>(){
         public int compare(IMethodBinding b1, IMethodBinding b2){

--- a/org.eclim.jdt/java/org/eclim/plugin/jdt/command/impl/DelegateCommand.java
+++ b/org.eclim.jdt/java/org/eclim/plugin/jdt/command/impl/DelegateCommand.java
@@ -52,7 +52,7 @@ import org.eclipse.jdt.core.dom.IVariableBinding;
 import org.eclipse.jdt.internal.corext.codemanipulation.AddDelegateMethodsOperation;
 import org.eclipse.jdt.internal.corext.codemanipulation.AddDelegateMethodsOperation.DelegateEntry;
 import org.eclipse.jdt.internal.corext.codemanipulation.CodeGenerationSettings;
-import org.eclipse.jdt.internal.corext.codemanipulation.StubUtility2;
+import org.eclipse.jdt.internal.corext.codemanipulation.StubUtility2Core;
 
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 
@@ -221,7 +221,7 @@ public class DelegateCommand
       throw new RuntimeException(ce);
     }
     DelegateEntry[] entries =
-      StubUtility2.getDelegatableMethods(typeBinding);
+      StubUtility2Core.getDelegatableMethods(typeBinding);
     ArrayList<DelegateEntry> delegatable = new ArrayList<DelegateEntry>();
     for (DelegateEntry entry : entries) {
       if (entry.field.equals(variable)){

--- a/org.eclim.jdt/java/org/eclim/plugin/jdt/command/impl/ImplCommand.java
+++ b/org.eclim.jdt/java/org/eclim/plugin/jdt/command/impl/ImplCommand.java
@@ -59,7 +59,7 @@ import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.formatter.CodeFormatter;
 
 import org.eclipse.jdt.internal.corext.codemanipulation.AddUnimplementedMethodsOperation;
-import org.eclipse.jdt.internal.corext.codemanipulation.StubUtility2;
+import org.eclipse.jdt.internal.corext.codemanipulation.StubUtility2Core;
 
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.Bindings;
@@ -317,7 +317,7 @@ public class ImplCommand
 
     IPackageBinding packageBinding = typeBinding.getPackage();
     IMethodBinding[] methods =
-      StubUtility2.getOverridableMethods(cu.getAST(), typeBinding, false);
+      StubUtility2Core.getOverridableMethods(cu.getAST(), typeBinding, false);
     ArrayList<IMethodBinding> overridable = new ArrayList<IMethodBinding>();
     for (IMethodBinding methodBinding : methods) {
       if (Bindings.isVisibleInHierarchy(methodBinding, packageBinding)){

--- a/org.eclim.jdt/java/org/eclim/plugin/jdt/command/include/ImportCommand.java
+++ b/org.eclim.jdt/java/org/eclim/plugin/jdt/command/include/ImportCommand.java
@@ -52,7 +52,7 @@ import org.eclipse.jdt.core.search.TypeNameMatch;
 import org.eclipse.jdt.internal.corext.codemanipulation.AddImportsOperation;
 import org.eclipse.jdt.internal.corext.codemanipulation.CodeGenerationMessages;
 import org.eclipse.jdt.internal.corext.codemanipulation.ContextSensitiveImportRewriteContext;
-import org.eclipse.jdt.internal.corext.codemanipulation.StubUtility;
+import org.eclipse.jdt.internal.core.manipulation.StubUtility;
 
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 

--- a/org.eclim.jdt/java/org/eclim/plugin/jdt/command/junit/JUnitImplCommand.java
+++ b/org.eclim.jdt/java/org/eclim/plugin/jdt/command/junit/JUnitImplCommand.java
@@ -58,7 +58,7 @@ import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.core.dom.rewrite.ImportRewrite;
 import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
 
-import org.eclipse.jdt.internal.corext.codemanipulation.StubUtility;
+import org.eclipse.jdt.internal.core.manipulation.StubUtility;
 
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 

--- a/org.eclim.jdt/java/org/eclim/plugin/jdt/util/JavaUtils.java
+++ b/org.eclim.jdt/java/org/eclim/plugin/jdt/util/JavaUtils.java
@@ -82,7 +82,7 @@ import org.eclipse.jdt.core.formatter.IndentManipulation;
 
 import org.eclipse.jdt.internal.core.DocumentAdapter;
 
-import org.eclipse.jdt.internal.corext.codemanipulation.StubUtility;
+import org.eclipse.jdt.internal.core.manipulation.StubUtility;
 
 import org.eclipse.jdt.internal.corext.refactoring.structure.ASTNodeSearchUtil;
 


### PR DESCRIPTION
This fixes the compile errors as mentioned in #601. However, updating the stubutility references as in this pull request will also bump the requirement of eclipse to 4.10+ so I'm guessing this change should probably also bump the version in changelog?

BR, David