### PR TITLE
Update :Validate command definition to prevent error

### DIFF
--- a/doc/content/vim/xml/index.rst
+++ b/doc/content/vim/xml/index.rst
@@ -99,8 +99,8 @@ following command is still available for validating xml files on demand.
 
 .. _\:Validate_xml:
 
-**:Validate** [<file>] -
-Validate the supplied file or the current file if no file name provided.
+**:Validate** -
+Validate the the current file.
 
 If eclimd is not currently running, and the xmllint command is available,
 eclim will validate the xml file using that.  Eclim will never use xmllint

--- a/org.eclim.core/vim/eclim/ftplugin/xml.vim
+++ b/org.eclim.core/vim/eclim/ftplugin/xml.vim
@@ -33,7 +33,7 @@ endif
 " Command Declarations {{{
 
 if !exists(":Validate")
-  command -nargs=0 -complete=file -bang -buffer Validate
+  command -nargs=0 -bang -buffer Validate
     \ :call eclim#xml#validate#Validate(0, '<bang>')
 
   command -nargs=? -buffer DtdDefinition


### PR DESCRIPTION
This change updates the `:Validate` command definition to drop the `-complete=file` option, and updates the docs to indicate the `:Validate` command does not take a file argument.

Otherwise, without this change, loading of `eclim/ftplugin/xml.vim` in versions of vim later than 8.2.3140 will fail with the error message `E1208: -complete used without -nargs` — due to this vim change: https://github.com/vim/vim/commit/de69a73

That change causes vim to explicitly check for the case where `-nargs=0` is used with `-complete` — because it doesn’t seem to make sense to use `-complete` without also actually permitting arguments for completion.

And in `org.eclim.core/vim/eclim/autoload/eclim/xml/validate.vim`, there doesn’t actually seem to be any support for handling any file argument passed to the `:Validate` command. So that’s why this patch drops the `-complete=file` option — rather than setting `-nargs=1` — and that’s why the patch also updates the docs to indicate `:Validate` takes no argument. Fixes #615. Related: https://github.com/vim/vim/pull/8544.

---

Incidentally, even with this fix (and even before the change to the vim sources which caused the error this patch prevents), running the `:Validate` command doesn’t actually seem to do anything — not in my environment at least.

When I run `:Validate` in a buffer for an Ant `build.xml` file that has XML well-formedness errors, vim doesn’t report any errors. The command invocation seems to have no effect. But then when I write/save the file, vim flags the errors (I guess because in that case, it’s running `xmllint` instead?…).